### PR TITLE
CLI: make flag types available in NestJS modules

### DIFF
--- a/packages/cli/src/base.command.ts
+++ b/packages/cli/src/base.command.ts
@@ -1,11 +1,11 @@
 import Command from '@oclif/command';
-import {Input} from '@oclif/parser';
+import parser from '@oclif/parser';
 import {INestApplicationContext, Type} from '@nestjs/common';
 import {NestFactory} from '@nestjs/core';
 import {IS_DEVELOPMENT_ENV} from './constants';
 
 export default abstract class BaseCommand extends Command {
-    protected abstract commandClass: Input<any>;
+    protected abstract commandClass: parser.Input<any>;
 
     protected abstract commandModule: Type<any>;
 

--- a/packages/cli/src/commands/dbms/access-token.ts
+++ b/packages/cli/src/commands/dbms/access-token.ts
@@ -13,7 +13,18 @@ export default class AccessTokenCommand extends BaseCommand {
 
     static flags = {
         ...DBMS_FLAGS,
-        credentials: flags.string({char: 'c'}),
-        principal: flags.string({char: 'p'}),
+        account: flags.string({
+            char: 'A',
+            description: 'Account to run the command against',
+            required: true,
+        }),
+        credentials: flags.string({
+            char: 'c',
+            required: true,
+        }),
+        principal: flags.string({
+            char: 'p',
+            required: true,
+        }),
     };
 }

--- a/packages/cli/src/commands/dbms/stop.ts
+++ b/packages/cli/src/commands/dbms/stop.ts
@@ -2,8 +2,8 @@ import {StopModule} from '../../modules/dbms/stop.module';
 import BaseCommand from '../../base.command';
 import {DBMS_FLAGS} from '../../constants';
 
-export default class StartCommand extends BaseCommand {
-    commandClass = StartCommand;
+export default class StopCommand extends BaseCommand {
+    commandClass = StopCommand;
 
     commandModule = StopModule;
 

--- a/packages/cli/src/modules/account/init.module.ts
+++ b/packages/cli/src/modules/account/init.module.ts
@@ -1,7 +1,8 @@
 import {OnApplicationBootstrap, Module, Inject} from '@nestjs/common';
 import cli from 'cli-ux';
-
 import {SystemModule, SystemProvider} from '@relate/common';
+
+import InitCommand from '../../commands/account/init';
 
 @Module({
     exports: [],
@@ -10,7 +11,7 @@ import {SystemModule, SystemProvider} from '@relate/common';
 })
 export class InitModule implements OnApplicationBootstrap {
     constructor(
-        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<any>,
+        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<typeof InitCommand>,
         @Inject('UTILS_PROVIDER') protected readonly utils: CommandUtils,
         @Inject(SystemProvider) protected readonly systemProvider: SystemProvider,
     ) {}

--- a/packages/cli/src/modules/dbms/access-token.module.ts
+++ b/packages/cli/src/modules/dbms/access-token.module.ts
@@ -4,6 +4,7 @@ import {trim} from 'lodash';
 import {prompt} from 'enquirer';
 
 import {isTTY, readStdin} from '../../stdin';
+import AccessTokenCommand from '../../commands/dbms/access-token';
 
 @Module({
     exports: [],
@@ -14,7 +15,7 @@ export class AccessTokenModule implements OnApplicationBootstrap {
     static DEFAULT_APP_ID = 'relate';
 
     constructor(
-        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<any>,
+        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<typeof AccessTokenCommand>,
         @Inject('UTILS_PROVIDER') protected readonly utils: CommandUtils,
         @Inject(SystemProvider) protected readonly systemProvider: SystemProvider,
     ) {}

--- a/packages/cli/src/modules/dbms/list.module.ts
+++ b/packages/cli/src/modules/dbms/list.module.ts
@@ -2,6 +2,7 @@ import {OnApplicationBootstrap, Module, Inject} from '@nestjs/common';
 import cli from 'cli-ux';
 
 import {SystemModule, SystemProvider} from '@relate/common';
+import ListCommand from '../../commands/dbms/list';
 
 @Module({
     exports: [],
@@ -10,7 +11,8 @@ import {SystemModule, SystemProvider} from '@relate/common';
 })
 export class ListModule implements OnApplicationBootstrap {
     constructor(
-        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<any>,
+        @Inject('PARSED_PROVIDER')
+        protected readonly parsed: ParsedInput<typeof ListCommand>,
         @Inject('UTILS_PROVIDER') protected readonly utils: CommandUtils,
         @Inject(SystemProvider) protected readonly systemProvider: SystemProvider,
     ) {}

--- a/packages/cli/src/modules/dbms/start.module.ts
+++ b/packages/cli/src/modules/dbms/start.module.ts
@@ -1,8 +1,9 @@
 import {OnApplicationBootstrap, Module, Inject} from '@nestjs/common';
 import {prompt} from 'enquirer';
-
 import {SystemModule, SystemProvider} from '@relate/common';
+
 import {readStdinArray, isTTY} from '../../stdin';
+import StartCommand from '../../commands/dbms/start';
 
 @Module({
     exports: [],
@@ -11,7 +12,7 @@ import {readStdinArray, isTTY} from '../../stdin';
 })
 export class StartModule implements OnApplicationBootstrap {
     constructor(
-        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<any>,
+        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<typeof StartCommand>,
         @Inject('UTILS_PROVIDER') protected readonly utils: CommandUtils,
         @Inject(SystemProvider) protected readonly systemProvider: SystemProvider,
     ) {}

--- a/packages/cli/src/modules/dbms/status.module.ts
+++ b/packages/cli/src/modules/dbms/status.module.ts
@@ -1,8 +1,9 @@
 import {OnApplicationBootstrap, Module, Inject} from '@nestjs/common';
 import cli from 'cli-ux';
-
 import {SystemModule, SystemProvider} from '@relate/common';
+
 import {readStdinArray, isTTY} from '../../stdin';
+import StatusCommand from '../../commands/dbms/status';
 
 @Module({
     exports: [],
@@ -11,7 +12,7 @@ import {readStdinArray, isTTY} from '../../stdin';
 })
 export class StatusModule implements OnApplicationBootstrap {
     constructor(
-        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<any>,
+        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<typeof StatusCommand>,
         @Inject('UTILS_PROVIDER') protected readonly utils: CommandUtils,
         @Inject(SystemProvider) protected readonly systemProvider: SystemProvider,
     ) {}

--- a/packages/cli/src/modules/dbms/stop.module.ts
+++ b/packages/cli/src/modules/dbms/stop.module.ts
@@ -4,6 +4,7 @@ import cli from 'cli-ux';
 
 import {SystemModule, SystemProvider} from '@relate/common';
 import {readStdinArray, isTTY} from '../../stdin';
+import StopCommand from '../../commands/dbms/stop';
 
 @Module({
     exports: [],
@@ -12,7 +13,7 @@ import {readStdinArray, isTTY} from '../../stdin';
 })
 export class StopModule implements OnApplicationBootstrap {
     constructor(
-        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<any>,
+        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<typeof StopCommand>,
         @Inject('UTILS_PROVIDER') protected readonly utils: CommandUtils,
         @Inject(SystemProvider) protected readonly systemProvider: SystemProvider,
     ) {}

--- a/packages/cli/typings/global.d.ts
+++ b/packages/cli/typings/global.d.ts
@@ -1,7 +1,14 @@
-import {Output} from '@oclif/parser';
+import parser, {flags} from '@oclif/parser';
+
+// https://itnext.io/typescript-extract-unpack-a-type-from-a-generic-baca7af14e51
+interface IHasFlags {
+    flags: any;
+}
+type UnpackFlags<InputFlags> = InputFlags extends flags.Input<infer TFlags> ? TFlags : never;
+type CommandToFlags<C> = C extends IHasFlags ? UnpackFlags<C['flags']> : {};
 
 declare global {
-    declare type ParsedInput<TFlags, TArgs = {[name: string]: string}> = Output<TFlags, TArgs>;
+    declare type ParsedInput<C> = parser.Output<CommandToFlags<C>, {[name: string]: any}>;
     declare type CommandUtils = {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         log: (message?: string | undefined, ...args: any[]) => void;


### PR DESCRIPTION
Now the types flag types specified in oclif commands will propagate to the NestJS modules. I also fixed a bug I found thanks to these types :sparkles: 