### PR TITLE
CLI: add command_not_found hook to extend CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,9 @@
     ],
     "oclif": {
         "commands": "./dist/commands",
+        "hooks": {
+            "command_not_found": "./dist/hooks/command-not-found"
+        },
         "bin": "relate",
         "plugins": [
             "@oclif/plugin-help",

--- a/packages/cli/src/hooks/command-not-found.ts
+++ b/packages/cli/src/hooks/command-not-found.ts
@@ -1,0 +1,36 @@
+import {Hook} from '@oclif/config';
+import {spawnSync} from 'child_process';
+import fse from 'fs-extra';
+import path from 'path';
+
+// Simplified version of:
+// https://github.com/springernature/hasbin/blob/master/lib/hasbin.js
+const binExists = async (bin: string): Promise<boolean> => {
+    const envPath = process.env.PATH || '';
+    const envExt = process.env.PATHEXT || '';
+    const extensions = envExt.split(path.delimiter);
+
+    const searchPaths = envPath
+        .replace(/["]+/g, '')
+        .split(path.delimiter)
+        .map((currentPath) => extensions.map((ext) => path.join(currentPath, bin + ext)))
+        .reduce((paths, currentPath) => paths.concat(currentPath), []);
+
+    const tests = searchPaths.map((currentPath) => fse.pathExists(currentPath));
+
+    const results = await Promise.all(tests);
+    return results.includes(true);
+};
+
+const commandNotFound: Hook<'command_not_found'> = async (options) => {
+    const command = `relate-${options.id}`;
+
+    if (await binExists(command)) {
+        spawnSync(command, process.argv.slice(3), {
+            stdio: 'inherit',
+        });
+        process.exit(0);
+    }
+};
+
+export default commandNotFound;

--- a/packages/common/src/environments/remote.environment.ts
+++ b/packages/common/src/environments/remote.environment.ts
@@ -7,7 +7,7 @@ import gql from 'graphql-tag';
 import path from 'path';
 import fse from 'fs-extra';
 
-import {AuthenticationError, FetchError, InvalidConfigError, NotAllowedError} from '../errors';
+import {FetchError, InvalidConfigError, NotAllowedError} from '../errors';
 import {EnvironmentConfigModel, IDbms, IDbmsVersion, IEnvironmentAuth} from '../models/environment-config.model';
 import {EnvironmentAbstract} from './environment.abstract';
 import {oAuthRedirectServer} from './oauth-utils';


### PR DESCRIPTION
This PR adds the possibility to add extra commands to the CLI by adding binaries named `relate-{command}` to the PATH. 

The way it works is, if a user runs a command that doesn't exist in our package, we'll search if a binary named `relate-{command}` exists. If it does it runs it, otherwise, it will throw the command not found error.