### PR TITLE
Npm install extensions

### DIFF
--- a/packages/common/src/system/system.provider.ts
+++ b/packages/common/src/system/system.provider.ts
@@ -315,6 +315,8 @@ export class SystemProvider implements OnModuleInit {
 
         await fse.copy(extractedDistPath, target);
 
+        // @todo: need to look at our use of exec (and maybe child processes) in general
+        // this does not account for all scenarios at the moment so needs more thought
         try {
             await new Promise((resolve, reject) => {
                 exec(


### PR DESCRIPTION
- use `exec` to run `npm install` for extensions
- left a todo as we need to look back at this, we are using exec and child processes (spawns) in the code so need to look at commonality. 