### PR TITLE
Add fixes for remote access token creation

### DIFF
--- a/packages/web/schema.graphql
+++ b/packages/web/schema.graphql
@@ -47,6 +47,7 @@ type Mutation {
 type Query {
   appLaunchData(launchToken: String!, appName: String!): AppLaunchData!
   installedApps: [AppData!]!
+  getDbms(environmentId: String, dbmsId: String!): Dbms!
   listDbmss(environmentId: String): [Dbms!]!
   statusDbmss(environmentId: String, dbmsIds: [String!]!): [String!]!
 }


### PR DESCRIPTION
We had a typo in our GraphQL request for creating access tokens, and `getDbms` was returning local addresses. I'm not sure the fix for `getDbms` is the best solution, but it's the best I could come up in a short time.
