### PR TITLE
dbms:start and stop prompts to display relevant dbmss

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,7 @@ $ npm install -g @relate/cli
 $ relate COMMAND
 running command...
 $ relate (-v|--version|version)
-@relate/cli/1.0.0 darwin-x64 node-v12.14.1
+@relate/cli/1.0.0 darwin-x64 node-v12.13.1
 $ relate --help [COMMAND]
 USAGE
   $ relate COMMAND

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -12,7 +12,7 @@ export const DBMS_FLAGS = {
     }),
 };
 
-export enum DBMS_FILTERS {
+export enum DBMS_STATUS_FILTERS {
     START = 'Neo4j is not running',
     STOP = 'Neo4j is running',
 }

--- a/packages/cli/src/modules/dbms/start.module.ts
+++ b/packages/cli/src/modules/dbms/start.module.ts
@@ -4,7 +4,7 @@ import {SystemModule, SystemProvider} from '@relate/common';
 import {readStdinArray, isInteractive} from '../../stdin';
 import StartCommand from '../../commands/dbms/start';
 import {selectDbmsPrompt} from '../../prompts';
-import {DBMS_FILTERS} from '../../constants';
+import {DBMS_STATUS_FILTERS} from '../../constants';
 
 @Module({
     exports: [],
@@ -25,7 +25,7 @@ export class StartModule implements OnApplicationBootstrap {
 
         if (!dbmsIds.length) {
             if (isInteractive()) {
-                const selectedDbms = await selectDbmsPrompt('Select a DBMS to start', environment, DBMS_FILTERS.START);
+                const selectedDbms = await selectDbmsPrompt('Select a DBMS to start', environment, DBMS_STATUS_FILTERS.START);
                 dbmsIds = [selectedDbms];
             } else {
                 dbmsIds = await readStdinArray();

--- a/packages/cli/src/modules/dbms/stop.module.ts
+++ b/packages/cli/src/modules/dbms/stop.module.ts
@@ -5,7 +5,7 @@ import {SystemModule, SystemProvider} from '@relate/common';
 import {readStdinArray, isInteractive} from '../../stdin';
 import StopCommand from '../../commands/dbms/stop';
 import {selectDbmsPrompt} from '../../prompts';
-import {DBMS_FILTERS} from '../../constants';
+import {DBMS_STATUS_FILTERS} from '../../constants';
 
 @Module({
     exports: [],
@@ -26,7 +26,7 @@ export class StopModule implements OnApplicationBootstrap {
 
         if (!dbmsIds.length) {
             if (isInteractive()) {
-                const selectedDbms = await selectDbmsPrompt('Select a DBMS to stop', environment, DBMS_FILTERS.STOP);
+                const selectedDbms = await selectDbmsPrompt('Select a DBMS to stop', environment, DBMS_STATUS_FILTERS.STOP);
                 dbmsIds = [selectedDbms];
             } else {
                 dbmsIds = await readStdinArray();

--- a/packages/cli/src/prompts/select.prompt.ts
+++ b/packages/cli/src/prompts/select.prompt.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import {prompt} from 'enquirer';
 import {Environment, IExtensionMeta, NotFoundError} from '@relate/common';
 
-import {DBMS_FILTERS} from '../constants';
+import {DBMS_STATUS_FILTERS} from '../constants';
 
 interface IChoice {
     name: string;
@@ -26,7 +26,7 @@ export const selectPrompt = async (message: string, choices: string[] | IChoice[
 export const selectDbmsPrompt = async (
     message: string,
     environment: Environment,
-    filter?: DBMS_FILTERS,
+    filter?: DBMS_STATUS_FILTERS,
 ): Promise<string> => {
     let dbmss = await environment.listDbmss();
     if (filter) {
@@ -44,7 +44,7 @@ export const selectDbmsPrompt = async (
         if (!filter) {
             throw new NotFoundError('No DBMS is installed', ['Run "relate dbms:install" and try again']);
         }
-        throw new NotFoundError(`All DBMSs are currently ${filter === DBMS_FILTERS.START ? 'running' : 'stopped'}`);
+        throw new NotFoundError(`All DBMSs are currently ${filter === DBMS_STATUS_FILTERS.START ? 'running' : 'stopped'}`);
     }
 
     return selectPrompt(


### PR DESCRIPTION
- `dbms:start` prompt to only show dbmss that are currently stopped or throw an error if all are running, and vice versa for `dbms:stop`