### PR TITLE
Build cli docs in non-interactive mode

### DIFF
--- a/packages/cli/docs/app.md
+++ b/packages/cli/docs/app.md
@@ -3,15 +3,15 @@
 
 Manage Graph Apps
 
-* [`relate app:open [APPNAME]`](#relate-appopen-appname)
+* [`relate app:open APPNAME`](#relate-appopen-appname)
 
-## `relate app:open [APPNAME]`
+## `relate app:open APPNAME`
 
 Open Graph App
 
 ```
 USAGE
-  $ relate app:open [APPNAME]
+  $ relate app:open APPNAME
 
 OPTIONS
   -D, --dbmsId=dbmsId            The DBMS to automatically connect to

--- a/packages/cli/docs/dbms.md
+++ b/packages/cli/docs/dbms.md
@@ -3,22 +3,22 @@
 
 Manage Neo4j DBMSs
 
-* [`relate dbms:access-token [DBMS]`](#relate-dbmsaccess-token-dbms)
+* [`relate dbms:access-token DBMS`](#relate-dbmsaccess-token-dbms)
 * [`relate dbms:info [DBMSS]`](#relate-dbmsinfo-dbmss)
-* [`relate dbms:install [VERSION]`](#relate-dbmsinstall-version)
+* [`relate dbms:install VERSION`](#relate-dbmsinstall-version)
 * [`relate dbms:list`](#relate-dbmslist)
-* [`relate dbms:open [DBMS]`](#relate-dbmsopen-dbms)
+* [`relate dbms:open DBMS`](#relate-dbmsopen-dbms)
 * [`relate dbms:start [DBMSS]`](#relate-dbmsstart-dbmss)
 * [`relate dbms:stop [DBMSS]`](#relate-dbmsstop-dbmss)
-* [`relate dbms:uninstall [DBMS]`](#relate-dbmsuninstall-dbms)
+* [`relate dbms:uninstall DBMS`](#relate-dbmsuninstall-dbms)
 
-## `relate dbms:access-token [DBMS]`
+## `relate dbms:access-token DBMS`
 
 Generate access token for a Neo4j DBMS
 
 ```
 USAGE
-  $ relate dbms:access-token [DBMS]
+  $ relate dbms:access-token DBMS
 
 ARGUMENTS
   DBMS  Name or ID of a Neo4j instance
@@ -54,20 +54,20 @@ OPTIONS
 
 _See code: [dist/commands/dbms/info.ts](https://github.com/neo-technology/daedalus/blob/v1.0.0/dist/commands/dbms/info.ts)_
 
-## `relate dbms:install [VERSION]`
+## `relate dbms:install VERSION`
 
 Install a Neo4j DBMS in the selected environment
 
 ```
 USAGE
-  $ relate dbms:install [VERSION]
+  $ relate dbms:install VERSION
 
 ARGUMENTS
   VERSION  Version to install (semver, url, or path)
 
 OPTIONS
   -e, --environment=environment  [default: default] Name of the environment to run the command against
-  -n, --name=name                Name to give the newly installed DBMS
+  -n, --name=name                (required) Name to give the newly installed DBMS
 ```
 
 _See code: [dist/commands/dbms/install.ts](https://github.com/neo-technology/daedalus/blob/v1.0.0/dist/commands/dbms/install.ts)_
@@ -92,13 +92,13 @@ OPTIONS
 
 _See code: [dist/commands/dbms/list.ts](https://github.com/neo-technology/daedalus/blob/v1.0.0/dist/commands/dbms/list.ts)_
 
-## `relate dbms:open [DBMS]`
+## `relate dbms:open DBMS`
 
 Open a Neo4j DBMS's directory
 
 ```
 USAGE
-  $ relate dbms:open [DBMS]
+  $ relate dbms:open DBMS
 
 ARGUMENTS
   DBMS  Name or ID of a Neo4j instance
@@ -144,13 +144,13 @@ OPTIONS
 
 _See code: [dist/commands/dbms/stop.ts](https://github.com/neo-technology/daedalus/blob/v1.0.0/dist/commands/dbms/stop.ts)_
 
-## `relate dbms:uninstall [DBMS]`
+## `relate dbms:uninstall DBMS`
 
 Uninstall a Neo4j DBMS from the selected environment
 
 ```
 USAGE
-  $ relate dbms:uninstall [DBMS]
+  $ relate dbms:uninstall DBMS
 
 ARGUMENTS
   DBMS  Name or ID of a Neo4j instance

--- a/packages/cli/docs/environment.md
+++ b/packages/cli/docs/environment.md
@@ -16,9 +16,9 @@ USAGE
   $ relate environment:init
 
 OPTIONS
-  --httpOrigin=httpOrigin  URL of the hosted instance of relate (only applies to --type=REMOTE)
-  --name=name              Name of the environment to initialize
-  --type=(LOCAL|REMOTE)    Type of environment
+  --httpOrigin=httpOrigin  (required) URL of the hosted instance of relate (only applies to --type=REMOTE)
+  --name=name              (required) Name of the environment to initialize
+  --type=(LOCAL|REMOTE)    (required) Type of environment
 
 ALIASES
   $ relate env:init

--- a/packages/cli/docs/extension.md
+++ b/packages/cli/docs/extension.md
@@ -5,7 +5,7 @@ Manage relate extensions
 
 * [`relate extension:install NAME`](#relate-extensioninstall-name)
 * [`relate extension:link [FILEPATH]`](#relate-extensionlink-filepath)
-* [`relate extension:uninstall [EXTENSION]`](#relate-extensionuninstall-extension)
+* [`relate extension:uninstall EXTENSION`](#relate-extensionuninstall-extension)
 
 ## `relate extension:install NAME`
 
@@ -33,13 +33,13 @@ USAGE
 
 _See code: [dist/commands/extension/link.ts](https://github.com/neo-technology/daedalus/blob/v1.0.0/dist/commands/extension/link.ts)_
 
-## `relate extension:uninstall [EXTENSION]`
+## `relate extension:uninstall EXTENSION`
 
 Uninstall an extension
 
 ```
 USAGE
-  $ relate extension:uninstall [EXTENSION]
+  $ relate extension:uninstall EXTENSION
 
 ARGUMENTS
   EXTENSION  Name of the extension to uninstall

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -94,7 +94,7 @@
         "build": "npm run prepack",
         "build:clean": "run-s clean build:tsc",
         "build:tsc": "tsc -b",
-        "build:manifest": "npm run dev-cli -- manifest",
+        "build:manifest": "npm run dev-cli -- manifest </dev/null",
         "build:readme": "npm run dev-cli -- readme --multi --dir=./docs",
         "clean": "rimraf dist",
         "test": "jest",


### PR DESCRIPTION
Our recent PRs often contained changes making most arguments optional or required. 

This happened because most flags have `required: REQUIRED_FOR_SCRIPTS`. I'm guessing not all of us are running the build script in the same way, so in some cases we are building in an interactive environment, and in other cases we aren't.

This also means the help pages are not really helpful at the moment when it comes to figuring out which arguments are required when scripting (since the required arguments keep changing).

This PR makes the `build:manifest` script run always in a non-interactive environment, so we get consistent and helpful docs.