### PR TITLE
Build cli docs in non-interactive mode (cross-platform)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,7 @@ $ npm install -g @relate/cli
 $ relate COMMAND
 running command...
 $ relate (-v|--version|version)
-@relate/cli/1.0.0 darwin-x64 node-v12.13.1
+@relate/cli/1.0.0 linux-x64 node-v12.16.1
 $ relate --help [COMMAND]
 USAGE
   $ relate COMMAND

--- a/packages/cli/docs/environment.md
+++ b/packages/cli/docs/environment.md
@@ -16,9 +16,9 @@ USAGE
   $ relate environment:init
 
 OPTIONS
-  --httpOrigin=httpOrigin  (required) URL of the hosted instance of relate (only applies to --type=REMOTE)
-  --name=name              (required) Name of the environment to initialize
-  --type=(LOCAL|REMOTE)    (required) Type of environment
+  --httpOrigin=httpOrigin     (required) URL of the hosted instance of relate (only applies to --type=REMOTE)
+  --name=name                 (required) Name of the environment to initialize
+  --type=(DEMO|LOCAL|REMOTE)  (required) Type of environment
 
 ALIASES
   $ relate env:init

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -94,7 +94,7 @@
         "build": "npm run prepack",
         "build:clean": "run-s clean build:tsc",
         "build:tsc": "tsc -b",
-        "build:manifest": "npm run dev-cli -- manifest </dev/null",
+        "build:manifest": "node -e '' | npm run dev-cli -- manifest",
         "build:readme": "npm run dev-cli -- readme --multi --dir=./docs",
         "clean": "rimraf dist",
         "test": "jest",


### PR DESCRIPTION
Rework the fix from https://github.com/neo-technology/daedalus/pull/58 to be cross-platform.