### PR TITLE
Revert "Distribute packages through GitHub registry"

### DIFF
--- a/documentation/FIRST_USE_GUIDE.md
+++ b/documentation/FIRST_USE_GUIDE.md
@@ -23,21 +23,11 @@ And will definitely find more issues and cases as adoption increases. Please hel
 - **We require NodeJS LTS (v12)** https://nodejs.org/en/
 - **We require OpenJDK v11.** https://cdn.azul.com/zulu/bin/ (search for 11.35.13-ca-jdk11.0.5)
 
-
-You will need to generate a GitHub personal access token to 
-login to the NPM registry:
-
-- Go to https://github.com/settings/tokens
-- Click "generate new token"
-- Add a name and check the "read:packages" permission
-- Click "generate new token"
-
-Using your GitHub username and the token from the previous step, login to the NPM registry:
+To install `@relate` you need to login to our private npm registry:
 ```shell script
-npm login --scope @relate --registry=https://npm.pkg.github.com/
+npm login --scope @relate --registry https://neo.jfrog.io/artifactory/api/npm/npm-local-private
 ```
-
-
+Credentials are stored in 1Password under `jfrog reader`
 
 Once authenticated you can install the CLI and WEB packages:
 ```shell script

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
             "ci": true
         },
         "publish": {
-            "registry": "https://npm.pkg.github.com/"
+            "registry": "https://neo.jfrog.io/artifactory/api/npm/npm-local-private"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "url": "git+https://github.com/neo-technology/daedalus.git"
     },
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com/"
+        "registry": "https://neo.jfrog.io/artifactory/api/npm/npm-local-private"
     },
     "scripts": {
         "prettify": "prettier --write 'packages/**/*.ts'",

--- a/packages/cli/.npmrc
+++ b/packages/cli/.npmrc
@@ -1,6 +1,6 @@
 save-exact=true
-@relate:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_password=
-//npm.pkg.github.com/:username=
-//npm.pkg.github.com/:email=
-//npm.pkg.github.com/:always-auth=true
+@relate:registry=https://neo.jfrog.io/artifactory/api/npm/npm-local-private/
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:_password=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:username=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:email=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:always-auth=true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
         "url": "git+https://github.com/neo-technology/daedalus.git"
     },
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com/"
+        "registry": "https://neo.jfrog.io/artifactory/api/npm/npm-local-private"
     },
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/client/.npmrc
+++ b/packages/client/.npmrc
@@ -1,6 +1,6 @@
 save-exact=true
-@relate:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_password=
-//npm.pkg.github.com/:username=
-//npm.pkg.github.com/:email=
-//npm.pkg.github.com/:always-auth=true
+@relate:registry=https://neo.jfrog.io/artifactory/api/npm/npm-local-private/
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:_password=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:username=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:email=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:always-auth=true

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,7 +10,7 @@
         "url": "git+https://github.com/neo-technology/daedalus.git"
     },
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com/"
+        "registry": "https://neo.jfrog.io/artifactory/api/npm/npm-local-private"
     },
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/common/.npmrc
+++ b/packages/common/.npmrc
@@ -1,6 +1,6 @@
 save-exact=true
-@relate:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_password=
-//npm.pkg.github.com/:username=
-//npm.pkg.github.com/:email=
-//npm.pkg.github.com/:always-auth=true
+@relate:registry=https://neo.jfrog.io/artifactory/api/npm/npm-local-private/
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:_password=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:username=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:email=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:always-auth=true

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -10,7 +10,7 @@
         "url": "git+https://github.com/neo-technology/daedalus.git"
     },
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com/"
+        "registry": "https://neo.jfrog.io/artifactory/api/npm/npm-local-private"
     },
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/electron/.npmrc
+++ b/packages/electron/.npmrc
@@ -1,6 +1,6 @@
 save-exact=true
-@relate:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_password=
-//npm.pkg.github.com/:username=
-//npm.pkg.github.com/:email=
-//npm.pkg.github.com/:always-auth=true
+@relate:registry=https://neo.jfrog.io/artifactory/api/npm/npm-local-private/
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:_password=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:username=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:email=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:always-auth=true

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -10,7 +10,7 @@
         "url": "git+https://github.com/neo-technology/daedalus.git"
     },
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com/"
+        "registry": "https://neo.jfrog.io/artifactory/api/npm/npm-local-private"
     },
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/web/.npmrc
+++ b/packages/web/.npmrc
@@ -1,6 +1,6 @@
 save-exact=true
-@relate:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_password=
-//npm.pkg.github.com/:username=
-//npm.pkg.github.com/:email=
-//npm.pkg.github.com/:always-auth=true
+@relate:registry=https://neo.jfrog.io/artifactory/api/npm/npm-local-private/
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:_password=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:username=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:email=
+//neo.jfrog.io/artifactory/api/npm/npm-local-private/:always-auth=true

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,7 +10,7 @@
         "url": "git+https://github.com/neo-technology/daedalus.git"
     },
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com/"
+        "registry": "https://neo.jfrog.io/artifactory/api/npm/npm-local-private"
     },
     "bin": {
         "relate-web": "./bin/run"


### PR DESCRIPTION
We can't publish packages with the `@relate` scope without owning a `relate` GitHub organization (GitHub NPM packages are named `@owner/repo`). Reverting for now until we'll have that organization. 

Reverts neo-technology/relate#67