### PR TITLE
rely on file paths solely from decompress

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,7 @@ $ npm install -g @relate/cli
 $ relate COMMAND
 running command...
 $ relate (-v|--version|version)
-@relate/cli/1.0.1-alpha.0 darwin-x64 node-v12.14.1
+@relate/cli/1.0.1-alpha.0 darwin-x64 node-v12.13.1
 $ relate --help [COMMAND]
 USAGE
   $ relate COMMAND

--- a/packages/cli/src/prompts/select.prompt.ts
+++ b/packages/cli/src/prompts/select.prompt.ts
@@ -99,11 +99,11 @@ export const selectAuthenticatorPrompt = async (): Promise<AuthenticatorOptions 
 };
 
 export const googleAuthenticatorPrompt = async (): Promise<AuthenticatorOptions> => {
-    const authenticationUrl = await inputPrompt('Authentication request URL (optional)',);
-    const redirectUrl = await inputPrompt('Authentication redirect URL (must match OAuth credentials)', '', true);
+    const authenticationUrl = await inputPrompt('Authentication request URL (optional)');
+    const redirectUrl = await inputPrompt('Authentication redirect URL (must match OAuth credentials)');
     const verificationUrl = await inputPrompt('Authentication verification URL (optional)');
-    const clientId = await inputPrompt('OAuth Client ID', '', true);
-    const clientSecret = await inputPrompt('OAuth Client Secret', '', true);
+    const clientId = await inputPrompt('OAuth Client ID');
+    const clientSecret = await inputPrompt('OAuth Client Secret');
 
     console.log(redirectUrl);
 

--- a/packages/common/src/utils/extract-neo4j.ts
+++ b/packages/common/src/utils/extract-neo4j.ts
@@ -1,28 +1,16 @@
 import _ from 'lodash';
-import fse from 'fs-extra';
-import decompress from 'decompress';
-import path from 'path';
 
-import {FileStructureError, DependencyError} from '../errors';
+import {FileStructureError} from '../errors';
 import {getDistributionInfo} from '../environments/local.environment/utils/dbms-versions';
 import {IDbmsVersion} from '../models';
+import { extract } from './extract';
 
 interface IExtractedArchive extends IDbmsVersion {
     extractedDistPath: string;
 }
 
 export const extractNeo4j = async (archivePath: string, outputDir: string): Promise<IExtractedArchive> => {
-    const outputFiles = await decompress(archivePath, outputDir);
-    // determine output dir filename from the shortest directory string path
-    const outputTopLevelDir = _.reduce(
-        _.filter(outputFiles, (file) => file.type === 'directory'),
-        (a, b) => (a.path.length <= b.path.length ? a : b),
-    );
-    if (!outputTopLevelDir) {
-        await Promise.all(_.map(outputFiles, (file) => fse.remove(path.join(outputDir, file.path))));
-        throw new FileStructureError(`Unexpected file structure after unpacking`);
-    }
-    const extractedDistPath = path.join(outputDir, outputTopLevelDir.path);
+    const extractedDistPath = await extract(archivePath, outputDir)
 
     // check if this is neo4j...
     try {
@@ -35,11 +23,6 @@ export const extractNeo4j = async (archivePath: string, outputDir: string): Prom
             extractedDistPath,
         };
     } catch (e) {
-        if (e.name === DependencyError.name) {
-            throw e;
-        }
-
-        await Promise.all(_.map(outputFiles, (file) => fse.remove(path.join(outputDir, file.path))));
         throw e;
     }
 };

--- a/packages/common/src/utils/extract.ts
+++ b/packages/common/src/utils/extract.ts
@@ -6,16 +6,14 @@ import {FileStructureError} from '../errors';
 
 export const extract = async (archivePath: string, outputDir: string): Promise<string> => {
     const outputFiles = await decompress(archivePath, outputDir);
+    // get unique top level file paths
+    const outputFilePaths = [...new Set(_.map(outputFiles, file => _.split(path.normalize(file.path), path.sep)[0]))];
 
-    // determine output dir filename from the shortest directory string path
-    const outputTopLevelDir = _.reduce(
-        _.filter(outputFiles, (file) => file.type === 'directory'),
-        (a, b) => (a.path.length <= b.path.length ? a : b),
-    );
-    if (!outputTopLevelDir) {
+    if (outputFilePaths.length !== 1) {
+        // delete the extracted output (not the archive)
         await Promise.all(_.map(outputFiles, (file) => fse.remove(path.join(outputDir, file.path))));
         throw new FileStructureError(`Unexpected file structure after unpacking`);
     }
 
-    return path.join(outputDir, outputTopLevelDir.path);
+    return path.join(outputDir, outputFilePaths[0]);
 };


### PR DESCRIPTION
- carries on from https://github.com/neo-technology/relate/pull/42/files
- rely solely on file paths to get the top level dir name when extracting from archives, as the output from `decompress` cannot be relied upon for anything more than just giving file paths of extracted files and that should be enough.
- I know we need to look at our flow of deletion of failed installs / archives, but can look at that after