### PR TITLE
Fix duplicate key error on Windows

### DIFF
--- a/documentation/CODE_STYLE.md
+++ b/documentation/CODE_STYLE.md
@@ -19,3 +19,20 @@ import {extract} from './download';
 // Don't do this if environment is a directory
 export * from './environment';
 ```
+
+-   Don't manipulate environment variables manually
+
+```typescript
+// This will throw an error on Windows
+spawn(binPath, ['start'], {
+    env: {
+        ...process.env,
+        PATH: process.env.PATH,
+    },
+});
+
+// This will handle case insentitive values correctly
+const env = new EnvVars({cloneFromProcess: true});
+env.set('PATH', process.env.PATH);
+spawn(binPath, ['start', {env}]);
+```

--- a/packages/common/src/utils/env-vars.ts
+++ b/packages/common/src/utils/env-vars.ts
@@ -1,0 +1,34 @@
+export class EnvVars {
+    private env: {[key: string]: string | undefined} = {};
+
+    constructor(options: {cloneFromProcess: boolean}) {
+        if (options && options.cloneFromProcess) {
+            this.env = {...process.env};
+        }
+    }
+
+    set(key: string, value: string | undefined): void {
+        if (process.platform !== 'win32') {
+            this.env[key] = value;
+            return;
+        }
+
+        // Windows environment variables are case insensitive
+        const targetKey = Object.keys(this.env).find((k) => k && k.toLowerCase() === key.toLowerCase());
+        this.env[targetKey || key] = value;
+    }
+
+    get(key: string): string | undefined {
+        if (process.platform !== 'win32') {
+            return this.env[key];
+        }
+
+        // Windows environment variables are case insensitive
+        const targetKey = Object.keys(this.env).find((k) => k && k.toLowerCase() === key.toLowerCase());
+        return this.env[targetKey || key];
+    }
+
+    toObject(): {[key: string]: string | undefined} {
+        return {...this.env};
+    }
+}

--- a/packages/common/src/utils/environment/neo4j-cmd.ts
+++ b/packages/common/src/utils/environment/neo4j-cmd.ts
@@ -6,6 +6,7 @@ import {NotAllowedError, NotFoundError, DependencyError} from '../../errors';
 import {NEO4J_BIN_DIR, NEO4J_BIN_FILE} from '../../environments/environment.constants';
 import {resolveRelateJavaHome} from './resolve-java';
 import {spawnPromise} from './spawn-promise';
+import {EnvVars} from '../env-vars';
 
 export async function neo4jCmd(dbmsRootPath: string, command: string): Promise<string> {
     const neo4jBinPath = path.join(dbmsRootPath, NEO4J_BIN_DIR, NEO4J_BIN_FILE);
@@ -15,14 +16,14 @@ export async function neo4jCmd(dbmsRootPath: string, command: string): Promise<s
         throw new NotFoundError(`No DBMS found at "${dbmsRootPath}"`);
     });
 
+    const env = new EnvVars({cloneFromProcess: true});
+    env.set('JAVA_HOME', relateJavaHome || process.env.JAVA_HOME);
+    // relateJavaHome is prepended to the PATH in order to take
+    // precedence over any user installed JAVA executable.
+    env.set('PATH', relateJavaHome ? `${relateJavaHome}${path.delimiter}${process.env.PATH}` : process.env.PATH);
+
     const output = await spawnPromise(neo4jBinPath, [command], {
-        env: {
-            ...process.env,
-            JAVA_HOME: relateJavaHome || process.env.JAVA_HOME,
-            // relateJavaHome is prepended to the PATH in order to take
-            // precedence over any user installed JAVA executable.
-            PATH: `${relateJavaHome || ''}${path.delimiter}${process.env.PATH}`,
-        },
+        env: env.toObject(),
     });
 
     if (output.includes('ERROR: Unable to find Java executable.')) {


### PR DESCRIPTION
On Windows this works fine:
```
spawn(binPath, ['start'], {
    env: { ...process.env }
});
```

But this will throw an error complaining about a key already existing
```
spawn(binPath, ['start'], {
    env: {
        ...process.env, 
        PATH: process.env.PATH 
    }
});
```

The issue turns out to be connected with the fact that Windows environment variables are case insensitive. In the second snippet, we have a Path key inside `process.env`, but we're also setting a PATH key. 

`process.env.PATH` and `process.env.Path` will actually have the same values because process.env has [custom getters](https://github.com/nodejs/node/blob/bb173f931ae85b464e901806f15dcc219dec6b73/src/node.cc#L2685GetEnvironmentVariableW) calling the [OS API](https://docs.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-getenvironmentvariablew), but the object we're passing to child_process.spawn will have two keys with the same name.

To solve this I created a utility to handle environment objects, so we don't have to remember quirks like these while still being able to handle this type of logic.