### PR TITLE
Update graphql resolvers

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -103,8 +103,8 @@ export enum PUBLIC_GRAPHQL_METHODS {
     LIST_DBMS_VERSIONS = 'listDbmsVersions',
     LIST_EXTENSION_VERSIONS = 'listExtensionVersions',
     UPDATE_DBMS_CONFIG = 'updateDbmsConfig',
-    INSTALLED_APPS = 'listInstalledApps',
-    INSTALLED_EXTENSIONS = 'listInstalledExtensions',
+    INSTALLED_APPS = 'listApps',
+    INSTALLED_EXTENSIONS = 'listExtensions',
     APP_LAUNCH_DATA = 'appLaunchData',
     CREATE_APP_LAUNCH_TOKEN = 'createAppLaunchToken',
 }

--- a/packages/common/src/entities/dbmss/dbmss.abstract.ts
+++ b/packages/common/src/entities/dbmss/dbmss.abstract.ts
@@ -42,6 +42,8 @@ export abstract class DbmssAbstract<Env extends EnvironmentAbstract> {
 
     abstract getDbmsConfig(dbmsId: string): Promise<PropertiesFile>;
 
+    abstract updateConfig(dbmsId: string, properties: Map<string, string>): Promise<boolean>;
+
     runQuery<Res = any>(
         driver: Driver<TapestryJSONResponse<Res>>,
         query: string,

--- a/packages/common/src/entities/dbmss/dbmss.remote.ts
+++ b/packages/common/src/entities/dbmss/dbmss.remote.ts
@@ -14,12 +14,21 @@ export class RemoteDbmss extends DbmssAbstract<RemoteEnvironment> {
     async updateConfig(dbmsId: string, properties: Map<string, string>): Promise<boolean> {
         const {data, errors}: any = await this.environment.graphql({
             query: gql`
-                mutation UpdateDbmsConfig($dbmsId: String!, $properties: [[String!, String!]]!) {
-                    ${PUBLIC_GRAPHQL_METHODS.UPDATE_DBMS_CONFIG}(dbmsId: $dbmsId, properties: $properties)
+                mutation UpdateDbmsConfig(
+                    $environmentId: String!,
+                    $dbmsId: String!,
+                    $properties: [[String!, String!]]!
+                ) {
+                    ${PUBLIC_GRAPHQL_METHODS.UPDATE_DBMS_CONFIG}(
+                        environmentId: $environmentId,
+                        dbmsId: $dbmsId,
+                        properties: $properties
+                    )
                 }
             `,
             variables: {
                 dbmsId,
+                environmentId: this.environment.relateEnvironment,
                 properties: properties.entries(),
             },
         });
@@ -37,15 +46,19 @@ export class RemoteDbmss extends DbmssAbstract<RemoteEnvironment> {
     async versions(): Promise<List<IDbmsVersion>> {
         const {data, errors}: any = await this.environment.graphql({
             query: gql`
-                query ListDbmsVersions {
-                    ${PUBLIC_GRAPHQL_METHODS.LIST_DBMS_VERSIONS} {
+                query ListDbmsVersions (
+                    $environmentId: String!
+                ) {
+                    ${PUBLIC_GRAPHQL_METHODS.LIST_DBMS_VERSIONS} (environmentId: $environmentId) {
                         edition
                         version
                         origin
                     }
                 }
             `,
-            variables: {},
+            variables: {
+                environmentId: this.environment.relateEnvironment,
+            },
         });
 
         if (errors) {

--- a/packages/web/schema.graphql
+++ b/packages/web/schema.graphql
@@ -45,19 +45,47 @@ type DbmsInfo {
   edition: String
 }
 
+type DbmsVersion {
+  edition: String!
+  version: String!
+  origin: String!
+  dist: String!
+}
+
+type ExtensionData {
+  type: String!
+  name: String!
+  version: String!
+  dist: String!
+  origin: String!
+}
+
+type ExtensionVersion {
+  type: String!
+  name: String!
+  version: String!
+  origin: String!
+}
+
 type Mutation {
   createAppLaunchToken(environmentId: String, accessToken: String, principal: String, dbmsId: String!, appName: String!): AppLaunchToken!
+  installExtension(environmentId: String, version: String!, name: String!): AppData!
+  uninstallExtension(environmentId: String, name: String!): [ExtensionData!]!
   installDbms(environmentId: String, name: String!, credentials: String!, version: String!): String!
   uninstallDbms(environmentId: String, name: String!): String!
   startDbmss(environmentId: String, dbmsIds: [String!]!): [String!]!
   stopDbmss(environmentId: String, dbmsIds: [String!]!): [String!]!
   createAccessToken(environmentId: String, dbmsId: String!, appName: String!, authToken: AuthTokenInput!): String!
+  updateDbmsConfig(environmentId: String, dbmsId: String!, properties: [[String!]!]!): Boolean!
 }
 
 type Query {
   appLaunchData(environmentId: String, launchToken: String!, appName: String!): AppLaunchData!
-  listInstalledApps(environmentId: String): [AppData!]!
+  listApps(environmentId: String): [AppData!]!
+  listExtensionVersions(environmentId: String): [ExtensionVersion!]!
+  listExtensions(environmentId: String): [AppData!]!
   getDbms(environmentId: String, dbmsId: String!): Dbms!
   listDbmss(environmentId: String): [Dbms!]!
   infoDbmss(environmentId: String, dbmsIds: [String!]!): [DbmsInfo!]!
+  listDbmsVersions(environmentId: String): [DbmsVersion!]!
 }

--- a/packages/web/src/apps/models/app-data.ts
+++ b/packages/web/src/apps/models/app-data.ts
@@ -1,5 +1,5 @@
 import {Field, ObjectType} from '@nestjs/graphql';
-import {EXTENSION_TYPES} from '@relate/common';
+import {EXTENSION_TYPES, EXTENSION_ORIGIN} from '@relate/common';
 
 @ObjectType()
 export class AppData {
@@ -14,4 +14,37 @@ export class AppData {
 
     @Field(() => String)
     path!: string;
+}
+
+@ObjectType()
+export class ExtensionData {
+    @Field(() => String)
+    type!: EXTENSION_TYPES;
+
+    @Field(() => String)
+    name!: string;
+
+    @Field(() => String)
+    version!: string;
+
+    @Field(() => String)
+    dist!: string;
+
+    @Field(() => String)
+    origin!: EXTENSION_ORIGIN;
+}
+
+@ObjectType()
+export class ExtensionVersion {
+    @Field(() => String)
+    type!: EXTENSION_TYPES;
+
+    @Field(() => String)
+    name!: string;
+
+    @Field(() => String)
+    version!: string;
+
+    @Field(() => String)
+    origin!: EXTENSION_ORIGIN;
 }

--- a/packages/web/src/apps/models/index.ts
+++ b/packages/web/src/apps/models/index.ts
@@ -1,3 +1,3 @@
 export {AppLaunchToken} from './app-launch-token';
 export {AppLaunchData} from './app-launch-data';
-export {AppData} from './app-data';
+export {AppData, ExtensionData, ExtensionVersion} from './app-data';

--- a/packages/web/src/dbms/dbms.resolver.ts
+++ b/packages/web/src/dbms/dbms.resolver.ts
@@ -1,7 +1,7 @@
 import {Resolver, Args, Mutation, Query} from '@nestjs/graphql';
 import {Inject, UseGuards} from '@nestjs/common';
 
-import {SystemProvider, PUBLIC_GRAPHQL_METHODS, IDbms, IDbmsInfo} from '@relate/common';
+import {SystemProvider, PUBLIC_GRAPHQL_METHODS, IDbms, IDbmsInfo, IDbmsVersion} from '@relate/common';
 import {
     Dbms,
     DbmsInfo,
@@ -11,6 +11,9 @@ import {
     InstallDbmsArgs,
     UninstallDbmsArgs,
     DbmsArgs,
+    DbmsVersion,
+    DbmsVersionArgs,
+    UpdateDbmsConfigArgs,
 } from './dbms.types';
 import {EnvironmentMethodGuard} from '../guards/environment-method.guard';
 
@@ -74,5 +77,22 @@ export class DBMSResolver {
         const environment = await this.systemProvider.getEnvironment(environmentId);
 
         return environment.dbmss.createAccessToken(appName, dbmsId, authToken);
+    }
+
+    @Query(() => [DbmsVersion])
+    async [PUBLIC_GRAPHQL_METHODS.LIST_DBMS_VERSIONS](
+        @Args() {environmentId}: DbmsVersionArgs,
+    ): Promise<IDbmsVersion[]> {
+        const environment = await this.systemProvider.getEnvironment(environmentId);
+        return (await environment.dbmss.versions()).toArray();
+    }
+
+    // @todo: do we want to allow updating dbms config here?
+    @Mutation(() => Boolean)
+    async [PUBLIC_GRAPHQL_METHODS.UPDATE_DBMS_CONFIG](
+        @Args() {environmentId, dbmsId, properties}: UpdateDbmsConfigArgs,
+    ): Promise<boolean> {
+        const environment = await this.systemProvider.getEnvironment(environmentId);
+        return environment.dbmss.updateConfig(dbmsId, new Map(properties));
     }
 }

--- a/packages/web/src/dbms/dbms.types.ts
+++ b/packages/web/src/dbms/dbms.types.ts
@@ -90,3 +90,36 @@ export class CreateAccessTokenArgs {
     @Field(() => AuthTokenInput)
     authToken: AuthTokenInput;
 }
+
+@ArgsType()
+export class DbmsVersionArgs {
+    @Field(() => String, {nullable: true})
+    environmentId?: string;
+}
+
+@ObjectType()
+export class DbmsVersion {
+    @Field(() => String)
+    edition: string;
+
+    @Field(() => String)
+    version: string;
+
+    @Field(() => String)
+    origin: string;
+
+    @Field(() => String)
+    dist: string;
+}
+
+@ArgsType()
+export class UpdateDbmsConfigArgs {
+    @Field(() => String, {nullable: true})
+    environmentId?: string;
+
+    @Field(() => String)
+    dbmsId: string;
+
+    @Field(() => [[String, String]])
+    properties: [string, string][];
+}


### PR DESCRIPTION
- added missing graphQL mutations/queries listed on `PUBLIC_GRAPHQL_METHODS`. If you know of any others, leave a comment.
- wasn't sure about the naming of extensions/apps and whether this warranted a new directory in `web/src`.