### PR TITLE
Changes to comply with Desktop 1.x

### DIFF
--- a/packages/cli/src/modules/db/dump.module.ts
+++ b/packages/cli/src/modules/db/dump.module.ts
@@ -41,7 +41,7 @@ export class DumpModule implements OnApplicationBootstrap {
 
         const dateISO = new Date().toISOString();
         const [date] = dateISO.split('.');
-        const file = path.join(to || `${dbms.name}-${database}-${date.replace(':', '')}.dump`);
+        const file = path.join(to || `${dbms.name}-${database}-${date.replace(/:/g, '')}.dump`);
 
         const filePath = path.resolve(file);
 

--- a/packages/common/src/entities/dbmss/dbmss.abstract.ts
+++ b/packages/common/src/entities/dbmss/dbmss.abstract.ts
@@ -134,9 +134,15 @@ export abstract class DbmssAbstract<Env extends EnvironmentAbstract> {
         }
     }
 
-    abstract dbDump(dbmsId: string, database: string, to: string): Promise<string>;
+    abstract dbDump(dbmsId: string, database: string, to: string, javaPath?: string): Promise<string>;
 
-    abstract dbLoad(dbmsId: string, database: string, from: string, force?: boolean): Promise<string>;
+    abstract dbLoad(
+        dbmsId: string,
+        database: string,
+        from: string,
+        force?: boolean,
+        javaPath?: string,
+    ): Promise<string>;
 
     abstract dbExec(
         dbmsId: string,

--- a/packages/common/src/utils/dbmss/neo4j-admin-cmd.ts
+++ b/packages/common/src/utils/dbmss/neo4j-admin-cmd.ts
@@ -7,9 +7,14 @@ import {resolveRelateJavaHome} from './resolve-java';
 import {spawnPromise} from './spawn-promise';
 import {EnvVars} from '../env-vars';
 
-export async function neo4jAdminCmd(dbmsRootPath: string, args: string[], credentials?: string): Promise<string> {
+export async function neo4jAdminCmd(
+    dbmsRootPath: string,
+    args: string[],
+    credentials?: string,
+    javaPath?: string,
+): Promise<string> {
     const neo4jAdminBinPath = path.join(dbmsRootPath, NEO4J_BIN_DIR, NEO4J_ADMIN_BIN_FILE);
-    const relateJavaHome = await resolveRelateJavaHome();
+    const relateJavaHome = javaPath || (await resolveRelateJavaHome());
 
     await fse.access(neo4jAdminBinPath, fse.constants.X_OK).catch(() => {
         throw new NotFoundError(`No DBMS found at "${dbmsRootPath}"`);


### PR DESCRIPTION
Allow sending paths to dbDump and dbLoad.

* dbmsId is either a DBMS ID or a path to a DBMS on disk.
* java executable path can also be supplied.