### PR TITLE
Common: add writeFile to projects

### DIFF
--- a/packages/common/src/entities/projects/projects.abstract.ts
+++ b/packages/common/src/entities/projects/projects.abstract.ts
@@ -1,7 +1,7 @@
 import {List} from '@relate/types';
 
 import {EnvironmentAbstract} from '../environments';
-import {IRelateFile, IProjectManifest, IProject, IProjectDbms, IDbms} from '../../models';
+import {IRelateFile, IProjectManifest, IProject, IProjectDbms, IDbms, WriteFileFlag} from '../../models';
 import {IRelateFilter} from '../../utils/generic';
 
 export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
@@ -17,13 +17,26 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
 
     abstract link(filePath: string): Promise<IProject>;
 
-    abstract listFiles(projectId: string, filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IRelateFile>>;
+    abstract listFiles(
+        projectName: string,
+        filters?: List<IRelateFilter> | IRelateFilter[],
+    ): Promise<List<IRelateFile>>;
 
-    abstract addFile(name: string, source: string, destination?: string): Promise<IRelateFile>;
+    abstract addFile(projectName: string, source: string, destination?: string): Promise<IRelateFile>;
 
-    abstract removeFile(name: string, relativePath: string): Promise<IRelateFile>;
+    abstract writeFile(
+        projectName: string,
+        destination: string,
+        data: string | Buffer,
+        writeFlag?: WriteFileFlag,
+    ): Promise<IRelateFile>;
 
-    abstract listDbmss(projectId: string, filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IProjectDbms>>;
+    abstract removeFile(projectName: string, relativePath: string): Promise<IRelateFile>;
+
+    abstract listDbmss(
+        projectName: string,
+        filters?: List<IRelateFilter> | IRelateFilter[],
+    ): Promise<List<IProjectDbms>>;
 
     abstract addDbms(
         projectName: string,

--- a/packages/common/src/entities/projects/projects.local.ts
+++ b/packages/common/src/entities/projects/projects.local.ts
@@ -4,12 +4,12 @@ import {from} from 'rxjs';
 import {flatMap, map} from 'rxjs/operators';
 import {List, Maybe, None, Str} from '@relate/types';
 
-import {IRelateFile, IProject, ProjectModel, IProjectManifest, IProjectDbms, IDbms} from '../../models';
+import {IRelateFile, IProject, ProjectModel, IProjectManifest, IProjectDbms, IDbms, WriteFileFlag} from '../../models';
 import {ProjectsAbstract} from './projects.abstract';
 import {LocalEnvironment} from '../environments';
 import {PROJECTS_MANIFEST_FILE, PROJECTS_DIR_NAME} from '../../constants';
 import {ErrorAbstract, InvalidArgumentError, NotFoundError} from '../../errors';
-import {getNormalizedProjectPath, mapFileToModel} from '../../utils/files';
+import {getRelativeProjectPath, mapFileToModel, getAbsoluteProjectPath} from '../../utils/files';
 import {envPaths} from '../../utils/env-paths';
 import {IRelateFilter, applyEntityFilters} from '../../utils/generic';
 
@@ -89,49 +89,70 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
         }
     }
 
+    private async getFile(project: IProject, filePath: string): Promise<Maybe<IRelateFile>> {
+        const target = getRelativeProjectPath(project, filePath);
+        const fileName = path.basename(target);
+        const projectDir = path.dirname(target);
+
+        const files = await this.listFiles(project.name);
+        return files.find(({name, directory}) => name === fileName && directory === projectDir);
+    }
+
     async addFile(projectName: string, source: string, destination?: string): Promise<IRelateFile> {
-        if (Str.from(destination).includes('..')) {
-            throw new InvalidArgumentError('Project files cannot be added outside of project');
-        }
-
         const project = await this.get(projectName);
-        const fileName = path.basename(destination || source).replace(project.root, '');
-        const projectDestination = destination || fileName;
-        const projectDir = getNormalizedProjectPath(path.dirname(projectDestination));
-        const existingFiles = await this.listFiles(project.name);
-        const filePredicate = ({name, directory}: IRelateFile) => name === fileName && directory === projectDir;
 
-        if (!existingFiles.find(filePredicate).isEmpty) {
-            throw new InvalidArgumentError(`File ${fileName} already exists at that destination`);
-        }
+        const target = getAbsoluteProjectPath(project, destination || path.basename(source));
+        const projectDir = path.dirname(target);
+        const fileName = path.basename(target);
 
-        const target = path.join(project.root, projectDestination);
+        const fileExists = await this.getFile(project, target);
+        fileExists.flatMap((file) => {
+            if (!None.isNone(file)) {
+                throw new InvalidArgumentError(`File ${file.name} already exists at that destination`);
+            }
+        });
 
-        await fse.ensureDir(path.dirname(target));
+        await fse.ensureDir(path.dirname(projectDir));
         await fse.copy(source, target);
 
-        const afterCopy = await this.listFiles(project.name);
-
-        return afterCopy.find(filePredicate).getOrElse(() => {
+        const afterCopy = await this.getFile(project, target);
+        return afterCopy.getOrElse(() => {
             throw new NotFoundError(`Unable to add ${fileName} to project`);
+        });
+    }
+
+    async writeFile(
+        projectName: string,
+        destination: string,
+        data: string | Buffer,
+        writeFlag?: WriteFileFlag,
+    ): Promise<IRelateFile> {
+        const project = await this.get(projectName);
+
+        const filePath = getAbsoluteProjectPath(project, destination);
+        await fse.writeFile(filePath, data, {
+            encoding: 'utf-8',
+            flag: writeFlag || WriteFileFlag.OVERWRITE,
+        });
+        const fileName = path.basename(filePath);
+
+        const afterWrite = await this.getFile(project, filePath);
+        return afterWrite.getOrElse(() => {
+            throw new NotFoundError(`Unable to write to file "${fileName}"`);
         });
     }
 
     async removeFile(projectName: string, relativePath: string): Promise<IRelateFile> {
         const project = await this.get(projectName);
-        const fileName = path.basename(relativePath);
-        const projectDir = getNormalizedProjectPath(path.dirname(relativePath));
-        const existingFiles = await this.listFiles(project.name);
-        const filePredicate = ({name, directory}: IRelateFile) => name === fileName && directory === projectDir;
+        const maybeFile = await this.getFile(project, relativePath);
 
-        return existingFiles.find(filePredicate).flatMap(async (found) => {
-            if (None.isNone(found)) {
+        return maybeFile.flatMap(async (file) => {
+            if (None.isNone(file)) {
                 throw new InvalidArgumentError(`File ${relativePath} does not exists`);
             }
 
-            await fse.unlink(path.join(project.root, relativePath));
-
-            return found;
+            await fse.unlink(path.join(project.root, file.directory, file.name));
+            return file;
         });
     }
 

--- a/packages/common/src/entities/projects/projects.remote.ts
+++ b/packages/common/src/entities/projects/projects.remote.ts
@@ -31,6 +31,10 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support adding project files`);
     }
 
+    writeFile(_projectName: string, _destination: string, _data: string | Buffer): Promise<IRelateFile> {
+        throw new NotSupportedError(`${RemoteProjects.name} does not support writing to project files`);
+    }
+
     removeFile(_name: string, _relativePath: string): Promise<IRelateFile> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support removing project files`);
     }

--- a/packages/common/src/models/project.model.ts
+++ b/packages/common/src/models/project.model.ts
@@ -1,6 +1,12 @@
 import {ModelAbstract} from './model.abstract';
 import {IsArray, IsString} from 'class-validator';
 
+// https://nodejs.org/api/fs.html#fs_file_system_flags
+export enum WriteFileFlag {
+    OVERWRITE = 'w+',
+    APPEND = 'a+',
+}
+
 export interface IProjectManifest {
     name: string;
     dbmss: IProjectDbms[];

--- a/packages/common/src/utils/files/map-file-to-model.ts
+++ b/packages/common/src/utils/files/map-file-to-model.ts
@@ -1,13 +1,14 @@
 import {IRelateFile, IProject} from '../../models';
 import path from 'path';
 import {TokenService} from '../../token.service';
+import {InvalidArgumentError} from '../../errors';
 
 export async function mapFileToModel(file: string, project: IProject): Promise<IRelateFile | null> {
     try {
         const fileObj = {
             name: path.basename(file),
             extension: path.extname(file),
-            directory: getNormalizedProjectPath(path.dirname(path.relative(project.root, file))),
+            directory: getRelativeProjectPath(project, path.dirname(file)),
         };
 
         return {
@@ -22,8 +23,18 @@ export async function mapFileToModel(file: string, project: IProject): Promise<I
     }
 }
 
-export function getNormalizedProjectPath(projectPath: string): string {
-    const dirname = path.normalize(projectPath);
+export function getAbsoluteProjectPath(project: IProject, filePath: string): string {
+    const absolutePath = path.normalize(path.resolve(project.root, filePath));
 
-    return path.normalize(dirname !== '.' ? `./${dirname}` : dirname);
+    if (filePath.includes('..') || !absolutePath.startsWith(project.root)) {
+        throw new InvalidArgumentError('Path must point to a location within the project directory');
+    }
+
+    return absolutePath;
+}
+
+export function getRelativeProjectPath(project: IProject, filePath: string): string {
+    const absolutePath = getAbsoluteProjectPath(project, filePath);
+
+    return path.relative(project.root, absolutePath) || '.';
 }


### PR DESCRIPTION
The behavior is pretty much the same as in fs.writeFile. If a file doesn't exist it will be created, and if a file exists it will be overwritten. We allow an enum for the writing mode, and at the moment we only support appending or overwriting. Not sure if there are other modes that make sense including, but here is the [full list of them](https://nodejs.org/api/fs.html#fs_file_system_flags).

I also had to clean up the way we handle paths in projects, as it was a bit hard to read, and some of the duplicate logic was missing in some places.