### PR TITLE
add suggestion to run relate env:use when relate web wont start

### DIFF
--- a/packages/common/src/system/system.provider.ts
+++ b/packages/common/src/system/system.provider.ts
@@ -71,7 +71,9 @@ export class SystemProvider implements OnModuleInit {
 
         return activeEnvironment.flatMap((env) => {
             if (None.isNone(env)) {
-                throw new NotFoundError(`No environment in use`);
+                throw new NotFoundError(`No environment in use`, [
+                    'Run relate env:use <environment> first to set an active environment',
+                ]);
             }
 
             return env;


### PR DESCRIPTION
- set a suggestion to run `relate env:use` when there is no active environment set and relate web does not start
- after speaking with @nglgzz , didn't do anything with setting an environment as active when its the first one created and no other set as active or touching any of that logic.