### PR TITLE
add projectId to app launch tokens

### DIFF
--- a/packages/cli/docs/app.md
+++ b/packages/cli/docs/app.md
@@ -17,6 +17,7 @@ OPTIONS
   -D, --dbmsId=dbmsId            The DBMS to automatically connect to
   -L, --log                      If set, log the path instead
   -e, --environment=environment  Name of the environment to run the command against
+  -p, --project=project          Name of the project to connect with
   -u, --user=user                The Neo4j DBMS user to automatically connect with, assuming an access token exists
 
 EXAMPLES

--- a/packages/cli/src/commands/app/open.ts
+++ b/packages/cli/src/commands/app/open.ts
@@ -41,5 +41,10 @@ export default class OpenCommand extends BaseCommand {
             description: 'The Neo4j DBMS user to automatically connect with, assuming an access token exists',
             required: false,
         }),
+        project: flags.string({
+            char: 'p',
+            description: 'Name of a project context to connect with',
+            required: false,
+        }),
     };
 }

--- a/packages/cli/src/modules/app/open.module.ts
+++ b/packages/cli/src/modules/app/open.module.ts
@@ -31,7 +31,7 @@ export class OpenModule implements OnApplicationBootstrap {
     async onApplicationBootstrap(): Promise<void> {
         const {args, flags} = this.parsed;
         let {appName} = args;
-        const {environment: environmentId, user, dbmsId} = flags;
+        const {environment: environmentId, user, dbmsId, project} = flags;
         const environment = await this.systemProvider.getEnvironment(environmentId);
         const installedApps = (await environment.extensions.listApps()).toArray();
 
@@ -76,7 +76,13 @@ export class OpenModule implements OnApplicationBootstrap {
         }
 
         const accessToken = await this.systemProvider.getAccessToken(environment.id, dbms.id, user);
-        const launchToken = await environment.extensions.createAppLaunchToken(appName, dbms.id, user, accessToken);
+        const launchToken = await environment.extensions.createAppLaunchToken(
+            appName,
+            dbms.id,
+            user,
+            accessToken,
+            project,
+        );
 
         const tokenUrl = `${appUrl}?_appLaunchToken=${launchToken}`;
         this.logOrOpen(tokenUrl);

--- a/packages/client/src/relate-client.class.ts
+++ b/packages/client/src/relate-client.class.ts
@@ -9,6 +9,7 @@ export interface IAppLaunchData {
         connectionUri: string;
     };
     principal?: string;
+    projectId?: string;
 }
 
 export interface IRelateClientConfig {

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -21,6 +21,7 @@ export function getParseLaunchTokenPayload(appName: string, launchToken: string)
                 connectionUri
               }
               principal
+              projectId
             }
           }
         `,

--- a/packages/common/src/entities/extensions/extensions.abstract.ts
+++ b/packages/common/src/entities/extensions/extensions.abstract.ts
@@ -27,6 +27,7 @@ export abstract class ExtensionsAbstract<Env extends EnvironmentAbstract> {
         dbmsId: string,
         principal?: string,
         accessToken?: string,
+        projectId?: string,
     ): Promise<string>;
 
     abstract parseAppLaunchToken(appName: string, launchToken: string): Promise<IAppLaunchToken>;

--- a/packages/common/src/entities/extensions/extensions.local.ts
+++ b/packages/common/src/entities/extensions/extensions.local.ts
@@ -186,7 +186,13 @@ export class LocalExtensions extends ExtensionsAbstract<LocalEnvironment> {
             .unwindPromises();
     }
 
-    createAppLaunchToken(appName: string, dbmsId: string, principal?: string, accessToken?: string): Promise<string> {
+    createAppLaunchToken(
+        appName: string,
+        dbmsId: string,
+        principal?: string,
+        accessToken?: string,
+        projectId?: string,
+    ): Promise<string> {
         const validated = JSON.parse(
             JSON.stringify(
                 new AppLaunchTokenModel({
@@ -195,6 +201,7 @@ export class LocalExtensions extends ExtensionsAbstract<LocalEnvironment> {
                     dbmsId,
                     environmentId: this.environment.id,
                     principal,
+                    projectId,
                 }),
             ),
         );
@@ -215,6 +222,7 @@ export class LocalExtensions extends ExtensionsAbstract<LocalEnvironment> {
                     dbmsId: decoded.dbmsId,
                     environmentId: decoded.environmentId,
                     principal: decoded.principal,
+                    projectId: decoded.projectId,
                 });
             })
             .catch((e) => {

--- a/packages/common/src/entities/extensions/extensions.remote.ts
+++ b/packages/common/src/entities/extensions/extensions.remote.ts
@@ -158,6 +158,7 @@ export class RemoteExtensions extends ExtensionsAbstract<RemoteEnvironment> {
         dbmsId: string,
         principal?: string,
         accessToken?: string,
+        projectId?: string,
     ): Promise<string> {
         const {data, errors}: any = await this.environment.graphql({
             query: gql`
@@ -165,13 +166,15 @@ export class RemoteExtensions extends ExtensionsAbstract<RemoteEnvironment> {
                     $dbmsId: String!,
                     $appName: String!,
                     $principal: String!,
-                    $accessToken: String!
+                    $accessToken: String!,
+                    $projectId: String!
                 ) {
                     ${PUBLIC_GRAPHQL_METHODS.CREATE_APP_LAUNCH_TOKEN}(
                         dbmsId: $dbmsId,
                         appName: $appName,
                         principal: $principal,
-                        accessToken: $accessToken
+                        accessToken: $accessToken,
+                        projectId: $projectId
                     ) {
                         token
                         path
@@ -183,6 +186,7 @@ export class RemoteExtensions extends ExtensionsAbstract<RemoteEnvironment> {
                 appName,
                 principal,
                 accessToken,
+                projectId,
             },
         });
 
@@ -212,6 +216,7 @@ export class RemoteExtensions extends ExtensionsAbstract<RemoteEnvironment> {
                         }
                         principal
                         accessToken
+                        projectId
                     }
                 }
             `,

--- a/packages/common/src/models/app-launch-token.model.ts
+++ b/packages/common/src/models/app-launch-token.model.ts
@@ -9,6 +9,7 @@ export interface IAppLaunchToken {
     principal?: string;
     appName: string;
     accessToken?: string;
+    projectId?: string;
 }
 
 export class AppLaunchTokenModel extends ModelAbstract<IAppLaunchToken> implements IAppLaunchToken {
@@ -29,4 +30,8 @@ export class AppLaunchTokenModel extends ModelAbstract<IAppLaunchToken> implemen
     @IsOptional()
     @IsValidJWT()
     accessToken?: string;
+
+    @IsString()
+    @IsOptional()
+    projectId?: string;
 }

--- a/packages/web/schema.graphql
+++ b/packages/web/schema.graphql
@@ -16,6 +16,7 @@ type AppLaunchData {
   dbms: Dbms!
   principal: String
   accessToken: String
+  project: Project
 }
 
 type AppLaunchToken {
@@ -89,10 +90,10 @@ enum FILTER_CONNECTORS {
 }
 
 type Mutation {
-  createAppLaunchToken(environmentNameOrId: String, appName: String!, dbmsId: String!, principal: String, accessToken: String): AppLaunchToken!
+  createAppLaunchToken(environmentNameOrId: String, appName: String!, dbmsId: String!, principal: String, accessToken: String, projectId: String): AppLaunchToken!
   installExtension(name: String!, environmentNameOrId: String, version: String!): AppData!
   uninstallExtension(environmentNameOrId: String, name: String!): [ExtensionData!]!
-  installDbms(environmentNameOrId: String, name: String!, credentials: String!, version: String!): String!
+  installDbms(environmentNameOrId: String, name: String!, credentials: String!, version: String!, noCaching: Boolean, limited: Boolean): String!
   uninstallDbms(environmentNameOrId: String, name: String!): String!
   startDbmss(environmentNameOrId: String, dbmsIds: [String!]!): [String!]!
   stopDbmss(environmentNameOrId: String, dbmsIds: [String!]!): [String!]!
@@ -100,7 +101,6 @@ type Mutation {
   updateDbmsConfig(dbmsId: String!, properties: [[String!]!]!): Boolean!
   createDb(dbmsId: String!, user: String!, accessToken: String!, dbName: String!): String!
   dropDb(dbmsId: String!, user: String!, accessToken: String!, dbName: String!): String!
-  listDbs(dbmsId: String!, user: String!, accessToken: String!): [Db!]!
   initProject(environmentNameOrId: String, name: String!): Project!
   addProjectDbms(name: String!, environmentNameOrId: String, dbmsName: String!, dbmsId: String!, user: String, accessToken: String): ProjectDbms!
   removeProjectDbms(name: String!, environmentNameOrId: String, dbmsName: String!): ProjectDbms!
@@ -129,7 +129,8 @@ type Query {
   getDbms(environmentNameOrId: String, dbmsId: String!): Dbms!
   listDbmss(filters: [RelateSimpleFilter!], environmentNameOrId: String): [Dbms!]!
   infoDbmss(environmentNameOrId: String, dbmsIds: [String!]!): [DbmsInfo!]!
-  listDbmsVersions(filters: [RelateSimpleFilter!]): [DbmsVersion!]!
+  listDbmsVersions(filters: [RelateSimpleFilter!], environmentNameOrId: String, limited: Boolean): [DbmsVersion!]!
+  listDbs(dbmsId: String!, user: String!, accessToken: String!): [Db!]!
   listProjects(filters: [RelateSimpleFilter!], environmentNameOrId: String): [Project!]!
   getProject(environmentNameOrId: String, name: String!): Project!
 }

--- a/packages/web/src/extensions/extensions.e2e.ts
+++ b/packages/web/src/extensions/extensions.e2e.ts
@@ -2,7 +2,17 @@ import {INestApplication} from '@nestjs/common';
 import {Test} from '@nestjs/testing';
 import {ConfigModule} from '@nestjs/config';
 import request from 'supertest';
-import {Environment, TestDbmss, TestExtensions, IInstalledExtension, STATIC_APP_BASE_ENDPOINT} from '@relate/common';
+import {
+    Environment,
+    TestDbmss,
+    TestExtensions,
+    IInstalledExtension,
+    STATIC_APP_BASE_ENDPOINT,
+    envPaths,
+    PROJECTS_DIR_NAME,
+} from '@relate/common';
+import fse from 'fs-extra';
+import path from 'path';
 
 import configuration from '../configs/dev.config';
 import {WebModule} from '../web.module';
@@ -12,6 +22,7 @@ let TEST_DB_ID: string;
 const TEST_ACCESS_TOKEN =
     // eslint-disable-next-line max-len
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NUb2tlbiI6eyJzY2hlbWUiOiJiYXNpYyIsInByaW5jaXBhbCI6Im5lbzRqIiwiY3JlZGVudGlhbHMiOiJleUo0TldNaU9sc2lUVWxKUmtocVEwTkJkMkZuUVhkSlFrRm5TVU5GUVZGM1JGRlpTa3R2V2tsb2RtTk9RVkZGVEVKUlFYZFRSRVZNVFVGclIwRXhWVVZDYUUxRFZUQlZlRVI2UVU1Q1owNVdRa0ZuVFVKc1RqTmFWMUpzWW1wRlUwMUNRVWRCTVZWRlEyZDNTbFJ0Vm5aT1IyOW5VMWMxYWsxU1VYZEZaMWxFVmxGUlJFUkJkRTlhVnpnd1lXbENTbUp1VW14amFrRmxSbmN3ZVUxRVFYbE5hbFYzVDBSQmQwNUVRbUZHZHpCNlRVUkJlVTFxU1hkUFJFRjNUa1JDWVUxR1JYaERla0ZLUW1kT1ZrSkJXVlJCYkU1R1RWRTRkMFJSV1VSV1VWRkpSRUZhVkdReVZtdGFWelI0UldwQlVVSm5UbFpDUVc5TlExVTFiR0o2VW5GSlJXeDFXWHBGWkUxQ2MwZEJNVlZGUVhkM1ZWUnRWblpPUjI5blVUSldlV1JEUWxkWlYzaHdXa2RHTUdJelNYZG5aMFZwVFVFd1IwTlRjVWRUU1dJelJGRkZRa0ZSVlVGQk5FbENSSGRCZDJkblJVdEJiMGxDUVZGRFhDOVFNMFppU0ZNNVNXOUllV3RjTDNSVk5sZ3liME5SZEVKTFMweElkbHBrZG5oTFpUVkZNbHBRVkZsTlYyWTRSMnRQVDB4Sk5FSjRUMHR2Wmt4UFRGbzVaVGRMTWxaaGNsa3pObkpHZVhKYWJrVmNMMXd2WjNjclVYbHlRVUpCUkRGaFlUVnlWRzVyYjB0NWNHdzBWM2x3ZVU5VGFGWkplbTlXVWswek1FY3diREJIVVhVcmRHaFlUMDVYTW01QlQwWlRWMjlZVm1ZMVJXSkVUMkZ3YWt0b2EwZFlUSFkzUkV4M2NIcFFPREV5ZDFaVFZUQTVkbVZJWkdScE1tdFNWVlpZYURkc05HRk9aRW9yZDI5NGJWZFBUbWcyVmpCUE1rRnFTMk5xTkd4UWEzTmlPWGx3Tmx3dldYZENNbkk1ZFhsYWJHMUlTMmxGUm5OVk1XVllXWGQxU0U5R01XdE9iVk5qWkZScWRIbFpkMUJjTDB4dlhDOUhkakI1T1VSbU5EWnZlSE52ZEhCb1drNTNRMHhSWkdkVVFXWkRkR2hrYkZvemFEUmFaVTlqYUhKelVqSklhMlpjTDBSRVZtVkJkWGRTWWxJeWVqSkdaaXRuTVVGblRVSkJRVWRxWjJkRlNFMUpTVUpCZWtGS1FtZE9Wa2hTVFVWQmFrRkJUVUpGUjBOWFEwZFRRVWRISzBWSlFrRlJVVVZCZDBsR2IwUkJla0puYkdkb2EyZENhSFpvUTBGUk1FVkthRmxyVkROQ2JHSnNUbFJVUTBKSVdsYzFiR050UmpCYVYxRm5VVEo0Y0ZwWE5UQkpSVTVzWTI1U2NGcHRiR3BaV0ZKc1RVSXdSMEV4VldSRVoxRlhRa0pTUTNKMWVHbFJiVTVNU1VJNGJXRkRlVXBsWlZCclpHTjRlbXRVUVdaQ1owNVdTRk5OUlVkRVFWZG5RbFI2Y0RReWFtd3pNR3RDVFhoQ1IweHZPV0kxVGxSaWVDdElOa1JCVDBKblRsWklVVGhDUVdZNFJVSkJUVU5DWlVGM1NGRlpSRlpTTUd4Q1FsbDNSa0ZaU1V0M1dVSkNVVlZJUVhkSlIwTkRjMGRCVVZWR1FuZE5SVTFFT0VkQk1WVmtTSGRSTkUxRVdYZE9TMEY1YjBSRFIweHRhREJrU0VFMlRIazVjMkl5VG1oaVIyaDJZek5STms1cVFYZE5RemxxWTIxM2RtRlhOVEJhV0VwMFdsZFNjRmxZVW14TWJVNTVZa00xZDFwWE1IZEVVVmxLUzI5YVNXaDJZMDVCVVVWTVFsRkJSR2RuU1VKQlJIWjZTbXhyUWpGWFpucFNTRmRQZUhOUmVFNU1VRzFhVkZadFFsZzVUREJtYldaVU4xQkNibkJLZUhoV1dsUkhaR016YWxkamQyOUpURGhIVkU5bk9XaDFjRnBSTlhscVJ6ZFhhMW8xYjI4NE5XUmtRMmt6Ukc4eFYxQllZMnRCTkZFd2VVTlFOVFJpYjNaY0wzbGFiakJOVURjd1p6ZzJaM04yYlVONFkxa3hWV2hGUTJoVmQxd3ZUV2gwU0ZGTWFFbERia0pwVGtWRVFuWTRSWFpsUjB3M2FWTklSMXBvWEM5NlpHVlliVWxzY0c5MGVUa3JOMkpRU2paS1RuTlZUWFUwT0ROVFZGZFJjbVJTYmxSaFZXOXlRbmRzUkU5Q2ExVmxkWEJjTHpCb1NtdERPR3g0VEcwNFZuaDZhbWh0VEc0MU4xQlFXVzVQVFdOUlVYTklSRFF3VWpSYVozUnJObmxzUzIweFVXSjFNbWwzVGpJd1pHSTJaRmNyUTNGSVpVUndSemxZU0hWVVhDOXpiRVJFTjBOblZIVktZVkZhVlVkSk1XRjBWa2MwUm5CSWRrRXdlbWs0TWxwV1RsUnRNM0ZsVG1FemFFMW9iemhFWkRoVlZrVmFOalJYVVZVME5HRlBiMXd2ZFVwSllrMTZRV2NyT0ZSUFlsWjFhRXRvYTFKMGRreG9UMW8yUjBZeVpUVmtLM2xHZFhGMVQyRjVVbEZKTTA4d1NrWjRibE5VWWtSRGJWaFNPVlYwT0U1UloyeGpTVzVOUW5OYVMzUldhSGxKUlU5MFpWWnNZM1ZVZVhwSFlVOUljR1pjTDJoQk0wbEtaMWg1YW01RVZIcFZTbFJJUmxkM1kzRm9kamN3VDFCa1ZVcG5NRmRrZDFaRVRUUjZNR3h0YTJKbVMwZEJORlp3YW1kU2NYUnBZVGR4VTJsMWN6VlJPRFJtZFZORVFUZFNPVEJJYjBaY0wxaENSSFZYV1hsemNteE1TMXd2Y2tSS1kwZEtVbE5rYTJ0eU1tZG1lV0YxU2x3dmR6QnpaRGw1WlhKb1NrcE9TemNyZVhSelQxbGNMM1Z6VVRkak16Wm9Ra2N4WjNWQ00yNU9SMU5IUlhVeGVreGxkRUZWZHpWdVdXUkZSRFZHYnpaYWMzWjFUSFJGUkRoQlZVZFlaRVp4U1V4WldUTkxXSFpEUm14UlFuRjJRM2hpZEhreWNEZzJTMFZrZFZWbUt5SmRMQ0owZVhBaU9pSktWMVFpTENKaGJHY2lPaUpTVXpVeE1pSjkuZXlKaGRXUWlPaUppYkc5dmJTSXNJbTVpWmlJNk1UVTROVGd6TWpreE1pd2ljMk52Y0dVaU9sc2lZV1J0YVc0aVhTd2lhWE56SWpvaWJtVnZOR29pTENKbWJHRm5jeUk2VzEwc0ltVjRjQ0k2TVRVNE9EUXlORGt4TWl3aWFXRjBJam94TlRnMU9ETXlPVEV5TENKcWRHa2lPaUl6VGxsM2JtczBlaUlzSW5WelpYSnVZVzFsSWpvaWJtVnZOR29pZlEuU0RqSEItWXI1a3JROVJvdmxsaGtIM1kycVJQMzlOQy1kanZfYzdna0x1UXpKcmVueDY5RVY5MUxxYThUYnM0V0NjWDNFU2Q0MW1wUkdvbXVjR01LY0lON190Qm03SE5weXBVam03MlJaWHAyWlM5b0hTb1V4WndVekg3OFVvbHdJUHFuLXd5Vk9iWmxBRURzNnBfYmdSOGpNc1Z4X1g1bnhhT0FmLVVUY2J5WGVGOVgxbkVXMFd1TnN3T0N0WjZpZm9qSi1xbzRkWEI3eGNiMWQ1MnptVDFvZGZQdzBPXzRoTFNTZU81NWIwZ3g4OXZTMmJBUWYtNmpFSEZ0eVlJeFA1b05kWUZQa20yUkVlYkI2elZTWWV2ZzI5dDBOYzJRYUlxSVhtcU04OTNGRS1CeWQ2NlUwalphM2F5WmdQZXNBMll6dG85ZFRaNVhBY2FRR1pwMkJRIn0sImFjY291bnRJZCI6ImZvbyIsImFwcElkIjoiYmxvb20iLCJkYm1zSWQiOiJib20iLCJpYXQiOjE1ODU4MzMwODEsImV4cCI6MTU4NTkxOTQ4MX0.72dX69CwV9KJHZA9kz2n1ruwSx7znvM7uJjmvLZAF8w';
+const TEST_PROJECT_ID = 'test_project_id';
 
 const CREATE_APP_LAUNCH_TOKEN = {
     query: `
@@ -20,14 +31,16 @@ const CREATE_APP_LAUNCH_TOKEN = {
             $dbmsId: String!,
             $appName: String!,
             $principal: String!,
-            $accessToken: String!
+            $accessToken: String!,
+            $projectId: String!,
         ) {
             createAppLaunchToken(
                 environmentNameOrId: $environmentNameOrId,
                 dbmsId: $dbmsId,
                 appName: $appName,
                 principal: $principal,
-                accessToken: $accessToken
+                accessToken: $accessToken,
+                projectId: $projectId,
             ) {
                 token
                 path
@@ -53,6 +66,9 @@ const APP_LAUNCH_DATA = {
                 }
                 principal
                 accessToken
+                project {
+                    name
+                }
             }
         }
     `,
@@ -95,6 +111,7 @@ describe('AppsModule', () => {
     afterAll(async () => {
         await dbmss.teardown();
         await extensions.teardown();
+        await fse.remove(path.join(envPaths().data, PROJECTS_DIR_NAME, TEST_PROJECT_ID));
     });
 
     test('/graphql createAppLaunchToken', () => {
@@ -107,6 +124,7 @@ describe('AppsModule', () => {
                     accessToken: TEST_ACCESS_TOKEN,
                     dbmsId: TEST_DB_ID,
                     appName: testExtension.name,
+                    projectId: TEST_PROJECT_ID,
                 },
             })
             .expect(HTTP_OK)
@@ -127,7 +145,12 @@ describe('AppsModule', () => {
             TEST_DB_ID,
             principal,
             TEST_ACCESS_TOKEN,
+            TEST_PROJECT_ID,
         );
+        const {name: projectName} = await testEnvironment.projects.create({
+            name: TEST_PROJECT_ID,
+            dbmss: [],
+        });
 
         return (
             request(app.getHttpServer())
@@ -152,6 +175,9 @@ describe('AppsModule', () => {
                         },
                         environmentId: expect.any(String),
                         principal: CREATE_APP_LAUNCH_TOKEN.variables.principal,
+                        project: {
+                            name: projectName,
+                        },
                     });
                 })
         );

--- a/packages/web/src/extensions/extensions.types.ts
+++ b/packages/web/src/extensions/extensions.types.ts
@@ -1,6 +1,7 @@
 import {ArgsType, Field, ObjectType} from '@nestjs/graphql';
 import {EXTENSION_ORIGIN, EXTENSION_TYPES} from '@relate/common';
 import {Dbms} from '../dbms/dbms.types';
+import {Project} from '../projects/projects.types';
 import {EnvironmentArgs} from '../global.types';
 
 @ObjectType()
@@ -40,6 +41,9 @@ export class AppLaunchData {
 
     @Field(() => String, {nullable: true})
     accessToken?: string;
+
+    @Field(() => Project, {nullable: true})
+    project?: Project;
 }
 
 @ObjectType()
@@ -85,6 +89,9 @@ export class CreateLaunchTokenArgs extends EnvironmentArgs {
 
     @Field(() => String, {nullable: true})
     accessToken: string;
+
+    @Field(() => String, {nullable: true})
+    projectId: string;
 }
 
 @ObjectType()


### PR DESCRIPTION
- added `projectId` to app launch tokens on web and common
- also added to `app:open` command and the `client` package but I was unsure of the context in terms of how a projectId and project context is used outside of Desktop so need input on this. Not sure what I have is even correct or needed?