### PR TITLE
Make global teardown of tests more reliable

### DIFF
--- a/scripts/tests/teardown.js
+++ b/scripts/tests/teardown.js
@@ -18,7 +18,8 @@ async function globalTeardown() {
             await env.dbmss.stop([dbms.id]);
             await env.dbmss.uninstall(dbms.id);
         })
-        .unwindPromises();
+        .unwindPromises()
+        .catch((err) => console.error(err));
 
     const cacheFiles = List.from(await fse.readdir(cachePath))
         .filter((filename) => !['.GITIGNORED', 'dbmss'].includes(filename))
@@ -34,8 +35,40 @@ async function globalTeardown() {
         .mapEach((filepath) => fse.remove(filepath))
         .unwindPromises();
 
-    // Do not remove this directory if not empty, it could lead to unexpected behavior.
-    await fse.rmdir(path.join(dataPath, DBMS_DIR_NAME));
+    const dbmssPath = path.join(dataPath, DBMS_DIR_NAME);
+    try {
+        // Do not remove this directory if not empty, it could lead to unexpected behavior.
+        await fse.rmdir(dbmssPath);
+    } catch {
+        // If the DBMS directory is not empty by now it means stopping and
+        // uninstalling through relate didn't work as expected. This is a last
+        // resort attempt to kill all running DBMSs and empty the directory.
+        const files = await fse.readdir(dbmssPath);
+        await List.from(files)
+            .mapEach(async (filename) => {
+                const filePath = path.join(dbmssPath, filename);
+                const stats = await fse.stat(filePath);
+
+                if (stats.isFile()) {
+                    await fse.remove(filePath);
+                    return;
+                }
+
+                const pidPath = path.join(filePath, 'run', 'neo4j.pid');
+
+                const dbmsIsRunning = await fse.pathExists(pidPath);
+                if (dbmsIsRunning) {
+                    const pid = await fse.readFile(pidPath).then((p) => p.toString().trim());
+
+                    // https://nodejs.org/api/process.html#process_signal_events
+                    await process.kill(pid, 'SIGKILL');
+                    console.log(`Killed DBMS process "${pid}"`);
+                }
+
+                await fse.remove(path.join(filePath));
+            })
+            .unwindPromises();
+    }
 }
 
 globalTeardown()


### PR DESCRIPTION
Currently, the global teardown script will fail if for some reason a DBMS is not stopped and uninstalled correctly. This can happen if some of the file operations we do in those steps times out or if the DBMS takes too long to shut down. 

This approach would be the safest approach if it wasn't for TeamCity deleting all files in the directory once tests are done. What I suspect is happening right now is that TeamCity is deleting the directories of running DBMSs, these DBMSs are re-creating some folders (mainly logs), and the teardown is failing because it's expecting the `data/dbmss` directory to be empty.

In this PR I'm handling this case by:
- Killing the DBMS processes if stopping them through relate didn't work.
- Allowing the `data/dbmss` directory to have some content by the end of the global teardown. 