### PR TITLE
bumped tapestry version

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -365,22 +365,17 @@
 			}
 		},
 		"@huboneo/tapestry": {
-			"version": "1.0.1-0",
-			"resolved": "https://registry.npmjs.org/@huboneo/tapestry/-/tapestry-1.0.1-0.tgz",
-			"integrity": "sha512-kUnPWbgoCDP2Kbrel2/4VTu9Ac+X18d9BGKDLGY6InT12vlO7AsRT8Y0vsDf03gZ6jXpAEd3JUoujkzpKmbtvw==",
+			"version": "1.0.1-1",
+			"resolved": "https://registry.npmjs.org/@huboneo/tapestry/-/tapestry-1.0.1-1.tgz",
+			"integrity": "sha512-yKvC/c3EdXjOlIYXxq2NZ9b3ljRJ/WEKlla4HtGcAjWZK8p4VMDqr6vyUJizdWokDR1yhNSC/WS2E5sTB5z00w==",
 			"requires": {
 				"autobind-decorator": "2.4.0",
-				"lodash": "4.17.15",
+				"lodash": "4.17.19",
 				"moment": "2.24.0",
 				"uuid": "3.3.3",
 				"ws": "7.2.1"
 			},
 			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				},
 				"uuid": {
 					"version": "3.3.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -56,7 +56,7 @@
         "graphql": "^15.0.0"
     },
     "dependencies": {
-        "@huboneo/tapestry": "1.0.1-0",
+        "@huboneo/tapestry": "1.0.1-1",
         "apollo-link": "1.2.14",
         "apollo-link-http": "1.5.17",
         "class-validator": "0.12.1",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bumps version of `@huboneo/tapestry` driver


### What is the current behavior?
Conflicting/cunfusing imports from tapestry clashing with `@relate/types`

### What is the new behavior?
Tapestry now uses `@relate/types` as well, removing confusion


### Does this PR introduce a breaking change?
No


### Other information:
