### PR TITLE
Fix DBMS logs on Windows

### DIFF
--- a/packages/common/neo4j-start.ps1
+++ b/packages/common/neo4j-start.ps1
@@ -1,0 +1,11 @@
+# Wrapper for the '.\neo4j.ps1 console' command to redirect output to the logs
+# file and hide the terminal that pops up when running the script.
+
+param (
+    # Path to neo4j.ps1
+    [Parameter(Mandatory=$true)][string]$binPath,
+    # Path to neo4j.log
+    [Parameter(Mandatory=$true)][string]$logsPath
+)
+
+Powershell -WindowStyle Hidden -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -File "$binPath" console *>> "$logsPath"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
DBMS logs on Windows are now correctly redirected to the `neo4j.log`.

### What is the current behavior?
When a DBMS is started on Windows logs show up in the terminal that pops up, but nothing is saved in the neo4j.log file.

### What is the new behavior?
Logs are now saved in the neo4j.log file and we no longer show terminals for started DBMSs.

### Does this PR introduce a breaking change?
No. 

### Other information:
