### PR TITLE
Don't reset the allow_upgrade when upgrading

### DIFF
--- a/packages/common/src/entities/dbmss/dbmss.local.ts
+++ b/packages/common/src/entities/dbmss/dbmss.local.ts
@@ -222,6 +222,9 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
 
                 await this.stop([upgradedDbms.id]);
                 await upgradedConfig.flush();
+            } else {
+                upgradedConfig.set('dbms.allow_upgrade', 'false');
+                await upgradedConfig.flush();
             }
 
             /**


### PR DESCRIPTION
Sometimes the upgrade hasn't completed before the DBMS was stopped and if the `allow_upgrade` flag is set to false, then the user can experience the "Database {DB} is not available" error.
