### PR TITLE
Fix flaky tests

### DIFF
--- a/packages/common/src/entities/dbmss/upgrade.test.ts
+++ b/packages/common/src/entities/dbmss/upgrade.test.ts
@@ -48,14 +48,14 @@ describe('LocalDbmss - upgrade', () => {
     });
 
     test('Upgrading to higher', async () => {
-        const upgraded = await env.dbmss.upgrade(dbms404.id, '4.0.5', true, false, true);
+        const upgraded = await env.dbmss.upgrade(dbms404.id, '4.0.5', true, false, false);
 
         expect(upgraded.version).toEqual('4.0.5');
         expect(upgraded.id).toEqual(dbms404.id);
     });
 
     test('Upgrading major', async () => {
-        const upgraded = await env.dbmss.upgrade(dbms35.id, '4.1.0', true, false, true);
+        const upgraded = await env.dbmss.upgrade(dbms35.id, '4.1.0', true, false, false);
 
         expect(upgraded.version).toEqual('4.1.0');
         expect(upgraded.id).toEqual(dbms35.id);

--- a/packages/common/src/utils/dbmss/dbms-versions.test.ts
+++ b/packages/common/src/utils/dbmss/dbms-versions.test.ts
@@ -21,7 +21,7 @@ describe('DBMS versions (local environment)', () => {
     test('list cached distributions', async () => {
         const dbmssDataDir = path.join(envPaths().cache, DBMS_DIR_NAME);
         const versions = (await discoverNeo4jDistributions(dbmssDataDir)).toArray();
-        expect(versions.length).toEqual(1);
+        expect(versions.length >= 1).toBeTruthy();
         expect(versions[0].edition).toEqual(NEO4J_EDITION.ENTERPRISE);
         expect(versions[0].origin).toEqual(NEO4J_ORIGIN.CACHED);
         expect(versions[0].dist).toContain(dbmssDataDir);

--- a/scripts/tests/setup.js
+++ b/scripts/tests/setup.js
@@ -4,9 +4,31 @@ const fse = require('fs-extra');
 
 const envSetup = require('../../e2e/jest-global.setup');
 const {TestDbmss, DBMS_DIR_NAME, envPaths} = require('../../packages/common');
+const {List} = require('../../packages/types');
 
 envSetup();
 const dbmssCache = path.join(process.env.NEO4J_RELATE_CACHE_HOME, DBMS_DIR_NAME);
+
+async function populateDistributionCache(env) {
+    const versions = List.of([TestDbmss.NEO4J_VERSION, '3.5.19', '4.0.5', '4.1.0']);
+
+    // Running the installations in sequence to avoid hogging resources
+    // (we're decompressing archives during the installation).
+    for (let version of versions) {
+        // This step is to populate the cache with the versions we want to test
+        // (in case the cache is not already populated). The DBMS is uninstalled
+        // right after as we're not really doing anything with it, we only care about
+        // the cached directory we get during installation.
+        await env.dbmss.install(
+            `global-setup-${version}`,
+            version,
+            TestDbmss.NEO4J_EDITION,
+            TestDbmss.DBMS_CREDENTIALS,
+            false,
+        );
+        await env.dbmss.uninstall(`global-setup-${version}`);
+    }
+}
 
 async function globalSetup() {
     await fse.emptyDir(envPaths().data);
@@ -16,14 +38,7 @@ async function globalSetup() {
     await fse.ensureFile(path.join(envPaths().data, 'acceptedTerms'));
 
     const env = (await TestDbmss.init('relate')).environment;
-
-
-    // This step is to populate the cache with the version we want to test
-    // (in case the cache is not already populated). The DBMS is uninstalled
-    // right after as we're not really doing anything with it, we only care about
-    // the cached directory we get during installation.
-    await env.dbmss.install('global-setup', TestDbmss.NEO4J_VERSION, TestDbmss.NEO4J_EDITION, TestDbmss.DBMS_CREDENTIALS);
-    await env.dbmss.uninstall('global-setup');
+    await populateDistributionCache(env);
 
     // Some tests require an archive of the DBMS to be passed to them, and
     // during installation we only keep the extracted directory, so we compress


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
This PR should reduce the flakiness of e2e tests. Currently the Mac pipeline on TeamCity is failing most of the time, even though it passes fine locally. The issue seems to be with resource usage, as the tests are failing on the upgrade tests, where we download and unarchive a few distributions. In this PR I populated the cache for those versions so when that test is run the load on the build server should be much lower. 

### What is the current behavior?
(You can also link to an open issue here)


### What is the new behavior?
(if this is a feature change)


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)


### Other information:
