### PR TITLE
Set PowerShell execution policy to "Bypass"

### DIFF
--- a/packages/common/src/utils/dbmss/neo4j-process-win.ts
+++ b/packages/common/src/utils/dbmss/neo4j-process-win.ts
@@ -68,7 +68,7 @@ export const winNeo4jStart = async (dbmsRoot: string): Promise<string> => {
 
     const child = spawn(
         'powershell.exe',
-        [cachedNeo4jStarterPath, '-binPath', neo4jPs1Path, '-logsPath', logFilePath],
+        ['-ExecutionPolicy', 'Bypass', cachedNeo4jStarterPath, '-binPath', neo4jPs1Path, '-logsPath', logFilePath],
         {
             detached: true,
             // Windows scripts are not executable on their own and need a shell to be able to run.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Execution policies determine what scripts can be run on PowerShell. On Windows the default policy is "Restricted", which disallows all scripts, and only allows single commands. This means that starting a DBMS currently fails if the execution policy hasn't been changed to "Unrestricted" or some similar value.

There are different scopes that this policy can be overridden at, and in our case, we can override it for our process by setting a flag on the PowerShell command. Or at least that's my understanding, and it seems to solve the issue.

More information can be found in [Microsoft's documentation](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7).
