### PR TITLE
Fix Java resolution on Windows

### DIFF
--- a/packages/common/src/utils/dbmss/resolve-java.ts
+++ b/packages/common/src/utils/dbmss/resolve-java.ts
@@ -73,7 +73,8 @@ export const downloadJava = async (dbmsVersion: string): Promise<void> => {
 
 export const resolveRelateJavaHome = async (dbmsVersion: string): Promise<string | null> => {
     const javaDirPath = path.join(envPaths().cache, RUNTIME_DIR_NAME, resolveJavaName(dbmsVersion).dirname);
-    const existsLocally = await fse.pathExists(path.join(javaDirPath, 'bin', 'java'));
+    const javaExecutable = process.platform === 'win32' ? 'java.exe' : 'java';
+    const existsLocally = await fse.pathExists(path.join(javaDirPath, 'bin', javaExecutable));
 
     if (existsLocally) {
         return javaDirPath;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Java wasn't being set on the Path environment variable on Windows when running the DBMS scripts. Turned out to be an issue with the check for the Java binary, which has a different name on Windows.


### What is the current behavior?
(You can also link to an open issue here)


### What is the new behavior?
(if this is a feature change)


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)


### Other information:
