### PR TITLE
node 14 fs.writeFile throws when trying to write number.

### DIFF
--- a/packages/common/src/utils/dbmss/neo4j-process-win.ts
+++ b/packages/common/src/utils/dbmss/neo4j-process-win.ts
@@ -90,7 +90,7 @@ export const winNeo4jStart = async (dbmsRoot: string): Promise<string> => {
     );
 
     const neo4jPidPath = path.join(dbmsRoot, NEO4J_RUN_DIR, NEO4J_RELATE_PID_FILE);
-    await fse.writeFile(neo4jPidPath, child.pid);
+    await fse.writeFile(neo4jPidPath, `${child.pid}`);
     child.unref();
 
     return 'neo4j started';


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix


### What is the current behavior?
dbms start fails on node 14


### What is the new behavior?
dbms start works on node 14


### Does this PR introduce a breaking change?
no


### Other information:
