### PR TITLE
Fix cloning of linked DBMSs

### DIFF
--- a/packages/common/src/entities/dbmss/clone.test.ts
+++ b/packages/common/src/entities/dbmss/clone.test.ts
@@ -1,0 +1,51 @@
+import path from 'path';
+import fse from 'fs-extra';
+import {TestDbmss} from '../../utils/system';
+import {IDbmsInfo} from '../../models';
+import {EnvironmentAbstract} from '../environments';
+import {DBMS_MANIFEST_FILE} from '../../constants';
+
+describe('LocalDbmss - clone', () => {
+    let testDbmss: TestDbmss;
+    let env: EnvironmentAbstract;
+    let originalDbms: IDbmsInfo;
+    let linkedDbmsPath: string;
+
+    beforeAll(async () => {
+        testDbmss = await TestDbmss.init(__filename);
+        env = testDbmss.environment;
+        originalDbms = await testDbmss.createDbms();
+        linkedDbmsPath = path.join(testDbmss.environment.dataPath, path.basename(originalDbms.rootPath!));
+    });
+
+    afterAll(async () => {
+        await testDbmss.teardown();
+        await fse.remove(linkedDbmsPath);
+    });
+
+    test('Clone a DBMS created by Relate', async () => {
+        const clonedName = testDbmss.createName();
+        const clonedDbms = await env.dbmss.clone(originalDbms.id, clonedName);
+
+        const originalAfterClone = await env.dbmss.get(originalDbms.id);
+
+        expect(originalAfterClone.name).toEqual(originalDbms.name);
+        expect(clonedDbms.name).toEqual(clonedName);
+    });
+
+    test('Clone a linked DBMS', async () => {
+        await fse.remove(path.join(originalDbms.rootPath!, DBMS_MANIFEST_FILE));
+        await fse.move(originalDbms.rootPath!, linkedDbmsPath);
+
+        const linkedName = testDbmss.createName();
+        const linkedDbms = await env.dbmss.link(linkedName, linkedDbmsPath!);
+
+        const clonedName = testDbmss.createName();
+        const clonedDbms = await env.dbmss.clone(linkedDbms.id, clonedName);
+
+        const linkedAfterClone = await env.dbmss.get(linkedDbms.id);
+
+        expect(linkedAfterClone.name).toEqual(linkedName);
+        expect(clonedDbms.name).toEqual(clonedName);
+    });
+});

--- a/packages/common/src/entities/dbmss/dbmss.local.ts
+++ b/packages/common/src/entities/dbmss/dbmss.local.ts
@@ -332,7 +332,10 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
         const dbms = await this.get(id);
         const clonedId = uuidv4();
 
-        await fse.copy(this.getDbmsRootPath(dbms.id), this.getDbmsRootPath(clonedId));
+        // If the DBMS is linked the target path should be copied, not the symlink.
+        const sourcePath = await fse.realpath(this.getDbmsRootPath(dbms.id));
+
+        await fse.copy(sourcePath, this.getDbmsRootPath(clonedId));
         await this.updateDbmsManifest(clonedId, {
             name,
         });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Now cloning linked DBMSs works as intended, copying the target directory instead of the symlink.

### What is the current behavior?
Currently cloning linked DBMSs only copies the symlink resulting in the original DBMS being modified. The issue has been reported here: https://community.neo4j.com/t/after-creating-a-project-and-database-how-do-i-get-back-to-no-project-databases/26165/4


### What is the new behavior?
(if this is a feature change)


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)


### Other information:
