### PR TITLE
Fix graphql-upload stream not complete

### DIFF
--- a/packages/web/src/entities/project/graphql-upload.ts
+++ b/packages/web/src/entities/project/graphql-upload.ts
@@ -1,12 +1,9 @@
 import * as FileType from 'file-type';
 import {GraphQLError, GraphQLScalarType} from 'graphql';
 import {Readable} from 'stream';
-import path from 'path';
-import {envPaths, FileUploadError} from '@relate/common';
 import fse from 'fs-extra';
-import {v4 as uuidv4} from 'uuid';
 
-export interface IFileUploadInput {
+export interface IFileUpload {
     filename: string;
     mimetype: string;
     encoding: string;
@@ -14,31 +11,19 @@ export interface IFileUploadInput {
     createReadStream: () => Readable;
 }
 
-export interface IFileUpload {
-    filename: string;
-    mimetype: string;
-    encoding: string;
-    path: string;
-}
-
 export const GraphQLUpload = new GraphQLScalarType({
     name: 'Upload',
     description: 'The `Upload` scalar type represents a file upload.',
-    async parseValue(value: Promise<IFileUploadInput>): Promise<IFileUpload> {
+    async parseValue(value: Promise<IFileUpload>): Promise<IFileUpload> {
         const upload = await value;
-        const tmpFileDir = path.join(envPaths().tmp, uuidv4());
-
-        await fse.ensureDir(tmpFileDir);
 
         // if we are coming from the sofa REST API the file has already been flushed to disk
         if (upload.path) {
-            const uploadedFilePath = path.join(tmpFileDir, upload.filename);
-
-            await fse.move(upload.path, uploadedFilePath);
+            const uploadedFilePath = upload.path;
 
             return {
                 ...upload,
-                path: uploadedFilePath,
+                createReadStream: () => fse.createReadStream(uploadedFilePath),
             };
         }
 
@@ -49,34 +34,12 @@ export const GraphQLUpload = new GraphQLScalarType({
             throw new GraphQLError('Mime type does not match file content.');
         }
 
-        const tmpFilePath = path.join(tmpFileDir, `${uuidv4()}.rdownload`);
-
-        try {
-            const uploadPromise = new Promise((resolve, reject) =>
-                stream
-                    .pipe(fse.createWriteStream(tmpFilePath))
-                    .on('finish', () => resolve())
-                    .on('error', (err) => reject(err)),
-            );
-
-            await uploadPromise;
-
-            const uploadedFilePath = path.join(tmpFileDir, upload.filename);
-
-            await fse.move(tmpFilePath, uploadedFilePath);
-
-            return {
-                ...upload,
-                path: uploadedFilePath,
-            };
-        } catch (e) {
-            throw new FileUploadError(`Failed to upload file ${upload.filename}: ${e.message}`);
-        }
+        return upload;
     },
     parseLiteral(ast): void {
         throw new GraphQLError('Upload literal unsupported.', ast);
     },
-    serialize(value: IFileUpload): IFileUpload {
+    serialize(value: IFileUpload): any {
         // sofa-api calls .serialize() on GraphQL scalars
         return {
             filename: value.filename,

--- a/packages/web/src/entities/project/project.resolver.ts
+++ b/packages/web/src/entities/project/project.resolver.ts
@@ -107,9 +107,10 @@ export class ProjectResolver {
         @Context('environment') environment: Environment,
         @Args() {name, fileUpload, destination}: AddProjectFileArgs,
     ): Promise<RelateFile> {
-        const {path: uploadPath} = await fileUpload;
+        const {filename, createReadStream} = await fileUpload;
+        const uploadedPath = await this.systemProvider.handleFileUpload(filename, createReadStream());
 
-        return environment.projects.addFile(name, uploadPath, destination);
+        return environment.projects.addFile(name, uploadedPath, destination);
     }
 
     @Mutation(() => RelateFile)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Fixes bug from https://github.com/neo4j-devtools/relate/pull/195 where uploads via graphql got corrupted due to `createReadStream` being called too early in the upload lifecycle.


### What is the current behavior?
Files uploaded via graphql corrupted


### What is the new behavior?
Files uploaded via graphql valid


### Does this PR introduce a breaking change?
no


### Other information:
