### PR TITLE
Use correct host URL when verifying API tokens

### DIFF
--- a/packages/cli/docs/dbms.md
+++ b/packages/cli/docs/dbms.md
@@ -129,7 +129,7 @@ USAGE
   $ relate dbms:link FILEPATH DBMSNAME
 
 OPTIONS
-  -y, --confirm=confirm  (required) Confirm DBMS configuration changes
+  -y, --confirm  (required) Confirm DBMS configuration changes
 
 EXAMPLE
   $ relate dbms:link /path/to/target/dbms/dir "foo bar"
@@ -292,6 +292,7 @@ OPTIONS
   -e, --environment=environment  Name of the environment to run the command against
   -v, --version=version          (required) Version to install (semver, url, or path)
   --no-caching                   Prevent caching of the downloaded DBMS
+  --no-migration                 Prevent migrating the data to new formats
 
 EXAMPLES
   $ relate dbms:upgrade

--- a/packages/cli/src/commands/dbms/link.ts
+++ b/packages/cli/src/commands/dbms/link.ts
@@ -25,7 +25,7 @@ export default class LinkCommand extends BaseCommand {
     ];
 
     static flags = {
-        confirm: flags.string({
+        confirm: flags.boolean({
             char: 'y',
             description: 'Confirm DBMS configuration changes',
             required: REQUIRED_FOR_SCRIPTS,

--- a/packages/cli/src/commands/dbms/upgrade.ts
+++ b/packages/cli/src/commands/dbms/upgrade.ts
@@ -26,5 +26,9 @@ export default class UpgradeCommand extends BaseCommand {
             default: false,
             description: 'Prevent caching of the downloaded DBMS',
         }),
+        'no-migration': flags.boolean({
+            default: false,
+            description: 'Prevent migrating the data to new formats',
+        }),
     };
 }

--- a/packages/cli/src/modules/dbms/upgrade.module.ts
+++ b/packages/cli/src/modules/dbms/upgrade.module.ts
@@ -25,6 +25,7 @@ export class UpgradeModule implements OnApplicationBootstrap {
         const {environment: environmentId} = flags;
         let {version = ''} = flags;
         const noCaching = flags['no-caching'];
+        const noMigration = flags['no-migration'];
         const environment = await this.systemProvider.getEnvironment(environmentId);
         let {dbms: dbmsId = ''} = args;
 
@@ -56,7 +57,7 @@ export class UpgradeModule implements OnApplicationBootstrap {
             version = choices.get(selected)!.version;
         }
 
-        return environment.dbmss.upgrade(dbms.id, version, noCaching).then((res) => {
+        return environment.dbmss.upgrade(dbms.id, version, !noMigration, noCaching).then((res) => {
             this.utils.log(getEntityDisplayName(res));
         });
     }

--- a/packages/cli/src/modules/environment/api-token.module.ts
+++ b/packages/cli/src/modules/environment/api-token.module.ts
@@ -27,8 +27,6 @@ export class APITokenModule implements OnApplicationBootstrap {
                 initial: new URL(environment.httpOrigin).host,
             }));
 
-        await environment.extensions.getAppPath(clientId);
-
         return environment.generateAPIToken(hostName, clientId, {}).then(this.utils.log);
     }
 }

--- a/packages/web/src/auth/services/auth.service.ts
+++ b/packages/web/src/auth/services/auth.service.ts
@@ -48,8 +48,12 @@ export class AuthService {
                 return;
             }
 
+            // Use the client URL otherwise fallback to the Relate server URL.
+            const requestUrl = req.get('origin') || environment.httpOrigin;
+            const requestHost = new URL(requestUrl).host;
+
             try {
-                await environment.verifyAPIToken(req.hostname, clientId, apiToken);
+                await environment.verifyAPIToken(requestHost, clientId, apiToken);
                 next();
             } catch (e) {
                 res.clearCookie(CLIENT_ID_HEADER);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?
- Fix the API token verification
- Pass the correct parameters to `dbms.upgrade` in the CLI module
- Use platform-independent paths when upgrading DBMSs
- Change the `--confirm` flag to boolean type on `dbms:link`

### What is the current behavior?
When verifying API tokens we use `req.hostname` as part of the token salt, which contains the origin URL in the format `<hostname>`, while when generating the tokens we use `<hostname>:<port>`. This means that currently all requests are rejected as unauthorized, even when they should be valid.

### What is the new behavior?
Tokens are now verified properly.

### Does this PR introduce a breaking change?
The `--confirm` flag on `dbms:link` is now a boolean instead of a string, so instead of calling the command as:
```
relate dbms:link <path> <name> --confirm=confirm
```
will have to be called as:
```
relate dbms:link <path> <name> --confirm
```