### PR TITLE
enable cors and req.origin string null check

### DIFF
--- a/packages/web/src/auth/services/auth.service.ts
+++ b/packages/web/src/auth/services/auth.service.ts
@@ -49,7 +49,8 @@ export class AuthService {
             }
 
             // Use the client URL otherwise fallback to the Relate server URL.
-            const requestUrl = req.get('origin') || environment.httpOrigin;
+            const requestUrl =
+                req.get('origin') && req.get('origin') !== 'null' ? req.get('origin')! : environment.httpOrigin;
             const requestHost = new URL(requestUrl).host;
 
             try {

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -10,15 +10,20 @@ export {ExtensionModule} from './entities/extension';
 
 export async function bootstrapWebModule(env = 'dev'): Promise<void> {
     const {default: configuration} = await require(`./configs/${env}.config`);
-    const app = await NestFactory.create({
-        imports: [
-            ConfigModule.forRoot({
-                isGlobal: true,
-                load: [configuration],
-            }),
-        ],
-        module: WebModule,
-    });
+    const app = await NestFactory.create(
+        {
+            imports: [
+                ConfigModule.forRoot({
+                    isGlobal: true,
+                    load: [configuration],
+                }),
+            ],
+            module: WebModule,
+        },
+        {
+            cors: true,
+        },
+    );
     const config = app.get(ConfigService);
 
     return app.listen(config.get('port'), config.get('host'));


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo-technology/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Enable CORS on web package and do a origin header string check. Similar change being added to bootstrapping of Relate module in Desktop

### What is the current behavior?
If origin is string 'null', currently being used as such. CORS not enabled.

### What is the new behavior?
CORS will be enabled and origin header of string 'null' will be handled correctly

### Does this PR introduce a breaking change?

### Other information:
