### PR TITLE
Add common and types docs when publishing

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -22,7 +22,9 @@
         "build:clean": "run-s clean build",
         "watch": "tsc -w",
         "start": "run-s build:clean watch",
-        "generate:docs": "typedoc"
+        "generate:docs": "typedoc",
+        "add:docs": "git add documentation",
+        "version": "run-s generate:docs add:docs"
     },
     "devDependencies": {
         "@nestjs/common": "7.0.8",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,9 +19,11 @@
         "clean": "rimraf dist",
         "build": "tsc",
         "build:clean": "run-s clean build",
-        "generate:docs": "typedoc",
         "start": "tsc -w",
-        "test": "jest"
+        "test": "jest",
+        "generate:docs": "typedoc",
+        "add:docs": "git add documentation",
+        "version": "run-s generate:docs add:docs"
     },
     "dependencies": {
         "lodash": "4.17.19"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Documentation from the common and types packages is now added to the release commit.


### What is the current behavior?
`common` and `types` docs are not added to the release commit.


### What is the new behavior?
`common` and `types` docs are added to the release commit.


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)


### Other information:
