### PR TITLE
Fix unauthorized requests when sending API requests from files

### DIFF
--- a/packages/web/src/auth/services/auth.service.ts
+++ b/packages/web/src/auth/services/auth.service.ts
@@ -48,9 +48,10 @@ export class AuthService {
                 return;
             }
 
+            const origin = req.get('origin');
             // Use the client URL otherwise fallback to the Relate server URL.
-            const requestUrl =
-                req.get('origin') && req.get('origin') !== 'null' ? req.get('origin')! : environment.httpOrigin;
+            // Requests coming from files might contain either 'null' or 'file://' in the Origin header.
+            const requestUrl = origin && origin !== 'null' && new URL(origin).host ? origin : environment.httpOrigin;
             const requestHost = new URL(requestUrl).host;
 
             try {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix.


### What is the current behavior?
When sending a request from a file, if the Origin header is `file://` instead of `null` the origin used to verify the token is an empty string. 


### What is the new behavior?
When sending a request from a file, if the Origin header is `file://` instead of `null` the origin used to verify the token defaults to Relate's HTTP origin. 


### Does this PR introduce a breaking change?
No.


### Other information:
