### PR TITLE
common/extensions install and web/extensions.e2e tests

### DIFF
--- a/packages/common/src/entities/extensions/extensions.local.ts
+++ b/packages/common/src/entities/extensions/extensions.local.ts
@@ -18,13 +18,13 @@ import {download, emitHookEvent} from '../../utils';
 import {applyEntityFilters, IRelateFilter, isValidUrl} from '../../utils/generic';
 import {
     discoverExtension,
-    discoverExtensionDistributions,
-    downloadExtension,
     extractExtension,
     fetchExtensionVersions,
     getAppBasePath,
     IExtensionVersion,
 } from '../../utils/extensions';
+import {downloadExtension} from '../../utils/extensions/download-extension';
+import {discoverExtensionDistributions} from '../../utils/extensions/extension-versions';
 import {ExtensionsAbstract} from './extensions.abstract';
 import {LocalEnvironment} from '../environments/environment.local';
 import {AppLaunchTokenModel, IAppLaunchToken, IExtensionInfo} from '../../models';

--- a/packages/common/src/entities/extensions/install.test.ts
+++ b/packages/common/src/entities/extensions/install.test.ts
@@ -1,0 +1,194 @@
+import path from 'path';
+
+import {TestExtensions} from '../../utils/system/test-extensions';
+import {TestDbmss} from '../../utils/system/test-dbmss';
+import {InvalidArgumentError} from '../../errors/invalid-argument.error';
+import * as extensionVersions from '../../utils/extensions/extension-versions';
+import * as downloadExtensionUtils from '../../utils/extensions/download-extension';
+import {EXTENSION_TYPES, EXTENSION_DIR_NAME, FILTER_COMPARATORS} from '../../constants';
+import {NotFoundError} from '../../errors/not-found.error';
+import {envPaths} from '../../utils/env-paths';
+import {ExtensionInfoModel, IExtensionInfo, IInstalledExtension} from '../../models/extension.model';
+import {List} from '@relate/types';
+
+describe('Extensions - install', () => {
+    let testExtensions: TestExtensions;
+    let testDbmss: TestDbmss;
+    const fileName = path.basename(__filename);
+
+    beforeAll(async () => {
+        testExtensions = new TestExtensions(__filename);
+        testDbmss = await TestDbmss.init(__filename);
+    });
+
+    afterAll(async () => {
+        await testExtensions.teardown();
+        await testDbmss.teardown();
+    });
+
+    describe('errors thrown', () => {
+        afterEach(() => jest.restoreAllMocks());
+
+        test('with no version', async () => {
+            await expect(testDbmss.environment.extensions.install(testExtensions.createName(), '')).rejects.toThrow(
+                new InvalidArgumentError('Version must be specified'),
+            );
+        });
+
+        test('with invalid version', async () => {
+            await expect(
+                testDbmss.environment.extensions.install(testDbmss.createName(), 'notAVersionOrUrlOrFilePath'),
+            ).rejects.toThrow(new InvalidArgumentError('Provided version argument is not valid semver, url or path.'));
+        });
+
+        test('with no existing version (file path or invalid URL)', async () => {
+            const message = 'Provided version argument is not valid semver, url or path.';
+            const testExtensionName = testDbmss.createName();
+
+            await expect(
+                testDbmss.environment.extensions.install(testExtensionName, path.join('non', 'existing', 'path')),
+            ).rejects.toThrow(new InvalidArgumentError(message));
+
+            await expect(
+                testDbmss.environment.extensions.install(testExtensionName, 'www/invalidurl.com'),
+            ).rejects.toThrow(new InvalidArgumentError(message));
+        });
+
+        test('with invalid, non cached version (semver)', async () => {
+            const invalidTestVersion = '0.0.0';
+            const TEST_EXTENSION_NAME = 'testExtension';
+            const spy = jest.spyOn(downloadExtensionUtils, 'downloadExtension').mockImplementation(() => {
+                throw new Error();
+            });
+
+            await expect(
+                testDbmss.environment.extensions.install(TEST_EXTENSION_NAME, invalidTestVersion),
+            ).rejects.toThrow(new NotFoundError(`Unable to find the requested version: ${invalidTestVersion} online`));
+            expect(spy).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalledWith(
+                TEST_EXTENSION_NAME,
+                invalidTestVersion,
+                path.join(envPaths().cache, EXTENSION_DIR_NAME),
+            );
+        });
+    });
+
+    describe('extension install/uninstall', () => {
+        let testCachedExtensionArchive: IInstalledExtension;
+        let testCachedExtension: IInstalledExtension;
+        const listExtensions = async (type: FILTER_COMPARATORS, value: string): Promise<IExtensionInfo[]> => {
+            return (
+                await testDbmss.environment.extensions.list([
+                    {
+                        field: 'name',
+                        type,
+                        value,
+                    },
+                ])
+            ).toArray();
+        };
+        const discoverDists = async (dirPath: string, value: string): Promise<ExtensionInfoModel[]> => {
+            return (await extensionVersions.discoverExtensionDistributions(dirPath))
+                .toArray()
+                .filter((ext) => ext.name.includes(value));
+        };
+
+        beforeAll(async () => {
+            testCachedExtensionArchive = await testExtensions.cacheArchive(EXTENSION_TYPES.STATIC);
+            testCachedExtension = await testExtensions.cacheNew(EXTENSION_TYPES.STATIC);
+        });
+
+        afterEach(() => jest.restoreAllMocks());
+
+        test('with valid version (file path)', async () => {
+            expect(await listExtensions(FILTER_COMPARATORS.CONTAINS, fileName)).toHaveLength(0);
+            expect(await discoverDists(testDbmss.environment.dirPaths.extensionsCache, fileName)).toHaveLength(1);
+
+            // install
+            const extensionInfo: IExtensionInfo = await testDbmss.environment.extensions.install(
+                testCachedExtensionArchive.name,
+                path.join(envPaths().cache, EXTENSION_DIR_NAME, `${testCachedExtensionArchive.name}.tgz`),
+            );
+            expect(extensionInfo.name).toEqual(testCachedExtensionArchive.name);
+
+            expect(
+                await discoverDists(testDbmss.environment.dirPaths.extensionsCache, testCachedExtensionArchive.name),
+            ).toHaveLength(0);
+            expect(await discoverDists(testDbmss.environment.dirPaths.extensionsData, fileName)).toHaveLength(1);
+
+            // extension is installed
+            expect(await listExtensions(FILTER_COMPARATORS.EQUALS, extensionInfo.name)).toHaveLength(1);
+
+            // will not reinstall existing extension
+            await expect(
+                testDbmss.environment.extensions.install(
+                    testCachedExtensionArchive.name,
+                    path.join(envPaths().cache, EXTENSION_DIR_NAME, `${testCachedExtensionArchive.name}.tgz`),
+                ),
+            ).rejects.toThrow(new InvalidArgumentError(`${testCachedExtensionArchive.name} is already installed`));
+            // installed extensions remain as before
+            expect(await listExtensions(FILTER_COMPARATORS.EQUALS, extensionInfo.name)).toHaveLength(1);
+        });
+
+        test('uninstalling extension removes extension from data dir', async () => {
+            expect(await listExtensions(FILTER_COMPARATORS.CONTAINS, fileName)).toHaveLength(1);
+
+            await testDbmss.environment.extensions.uninstall(
+                (await listExtensions(FILTER_COMPARATORS.CONTAINS, fileName))[0].name,
+            );
+
+            // extension should be deleted
+            expect(await listExtensions(FILTER_COMPARATORS.CONTAINS, fileName)).toHaveLength(0);
+            // extension should be deleted from data directory
+            expect(await discoverDists(testDbmss.environment.dirPaths.extensionsData, fileName)).toHaveLength(0);
+        });
+
+        test('with valid non-cached version (semver)', async () => {
+            expect(await listExtensions(FILTER_COMPARATORS.CONTAINS, fileName)).toHaveLength(0);
+
+            // mock no existing cached distributions
+            jest.spyOn(extensionVersions, 'discoverExtensionDistributions').mockResolvedValueOnce(List.from());
+            // mock download/extract of archive
+            const spy = jest
+                .spyOn(downloadExtensionUtils, 'downloadExtension')
+                .mockResolvedValue(
+                    extensionVersions.discoverExtension(
+                        path.join(testDbmss.environment.dirPaths.extensionsCache, `${testCachedExtension.name}`),
+                    ),
+                );
+
+            // install extension
+            await testDbmss.environment.extensions.install(testCachedExtension.name, testCachedExtension.version);
+            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledWith(
+                testCachedExtension.name,
+                testCachedExtension.version,
+                testDbmss.environment.dirPaths.extensionsCache,
+            );
+            // extracted extension in cache dir should exist in this case
+            expect(await discoverDists(testDbmss.environment.dirPaths.extensionsCache, fileName)).toHaveLength(1);
+            // extension is installed
+            expect((await listExtensions(FILTER_COMPARATORS.CONTAINS, fileName))[0].name).toBe(
+                testCachedExtension.name,
+            );
+        });
+
+        test('with valid cached version (semver)', async () => {
+            // clear previous installed extension
+            const installedExtensionName = (await listExtensions(FILTER_COMPARATORS.CONTAINS, fileName))[0].name;
+            await testDbmss.environment.extensions.uninstall(installedExtensionName);
+            expect(await listExtensions(FILTER_COMPARATORS.CONTAINS, fileName)).toHaveLength(0);
+
+            const spy = jest.spyOn(downloadExtensionUtils, 'downloadExtension');
+            // install from current cached extension
+            await testDbmss.environment.extensions.install(testCachedExtension.name, testCachedExtension.version);
+
+            // should extract from cached extension, not download
+            expect(spy).not.toHaveBeenCalled();
+            expect(await discoverDists(testDbmss.environment.dirPaths.extensionsCache, fileName)).toHaveLength(1);
+            expect((await listExtensions(FILTER_COMPARATORS.CONTAINS, fileName))[0].name).toBe(
+                testCachedExtension.name,
+            );
+        });
+    });
+});

--- a/packages/common/src/utils/extensions/extension-versions.test.ts
+++ b/packages/common/src/utils/extensions/extension-versions.test.ts
@@ -38,8 +38,13 @@ jest.mock('got', () => ({
 }));
 
 describe('extension versions', () => {
-    const extensions = new TestExtensions(__filename);
-    let testExtension: IInstalledExtension;
+    let extensions: TestExtensions;
+
+    beforeAll(() => {
+        extensions = new TestExtensions(__filename);
+    });
+
+    afterAll(() => extensions.teardown());
 
     describe('no extensions installed', () => {
         test('extension distributions empty (if none existing)', async () => {
@@ -47,7 +52,7 @@ describe('extension versions', () => {
                 await extensionVersions.discoverExtensionDistributions(path.join(envPaths().cache, EXTENSION_DIR_NAME))
             ).toArray();
 
-            expect(extensionMeta).toHaveLength(0);
+            expect(extensionMeta.some((ext) => ext.name.includes(path.basename(__filename)))).toBeFalsy();
         });
 
         test('extension distributions throws (if none existing)', async () => {
@@ -63,13 +68,13 @@ describe('extension versions', () => {
         test('extension version list (online error and no cached versions)', async () => {
             const extensionVersionList = (await extensionVersions.fetchExtensionVersions()).toArray();
 
-            expect(extensionVersionList).toHaveLength(0);
+            expect(extensionVersionList.some((ext) => ext.name.includes(path.basename(__filename)))).toBeFalsy();
         });
 
         test('extension version list (online and no cached versions)', async () => {
             const extensionVersionList = (await extensionVersions.fetchExtensionVersions()).toArray();
 
-            expect(extensionVersionList).toEqual([
+            expect(extensionVersionList.filter((ext) => ext.name.includes(TEST_EXTENSION))).toEqual([
                 {
                     name: TEST_EXTENSION,
                     origin: EXTENSION_ORIGIN.ONLINE,
@@ -80,54 +85,64 @@ describe('extension versions', () => {
     });
 
     describe('extensions installed', () => {
-        afterAll(() => extensions.teardown());
+        let testCachedExtension: IInstalledExtension;
+        let testDataExtension: IInstalledExtension;
+
+        beforeAll(async () => {
+            testCachedExtension = await extensions.cacheNew(EXTENSION_TYPES.STATIC);
+            testDataExtension = await extensions.installNew(EXTENSION_TYPES.STATIC);
+        });
 
         test('extensions discovered (if existing and with a package.json)', async () => {
-            testExtension = await extensions.installNew();
             const extensionMeta = await extensionVersions.discoverExtension(
-                path.join(envPaths().data, EXTENSION_DIR_NAME, EXTENSION_TYPES.STATIC, testExtension.name),
+                path.join(envPaths().data, EXTENSION_DIR_NAME, EXTENSION_TYPES.STATIC, testDataExtension.name),
             );
 
             expect(extensionMeta).toEqual({
-                name: testExtension.name,
-                dist: path.join(envPaths().data, EXTENSION_DIR_NAME, EXTENSION_TYPES.STATIC, testExtension.name),
-                main: testExtension.main,
-                root: testExtension.root,
+                name: testDataExtension.name,
+                dist: path.join(envPaths().data, EXTENSION_DIR_NAME, EXTENSION_TYPES.STATIC, testDataExtension.name),
+                main: testDataExtension.main,
+                root: testDataExtension.root,
                 official: false,
                 verification: EXTENSION_VERIFICATION_STATUS.UNSIGNED,
                 origin: EXTENSION_ORIGIN.CACHED,
-                type: testExtension.type,
-                version: testExtension.version,
+                type: testDataExtension.type,
+                version: testDataExtension.version,
             });
         });
 
         test('extension distributions discovered (if existing)', async () => {
-            testExtension = await extensions.cacheNew();
             const extensionMeta = (
                 await extensionVersions.discoverExtensionDistributions(path.join(envPaths().cache, EXTENSION_DIR_NAME))
-            ).toArray();
+            )
+                .toArray()
+                .filter((ext) => ext.name.includes(testCachedExtension.name));
+
+            expect(extensionMeta).toHaveLength(1);
 
             expect(extensionMeta[0]).toEqual({
-                name: testExtension.name,
-                dist: path.join(path.join(envPaths().cache, EXTENSION_DIR_NAME), testExtension.name),
-                main: testExtension.main,
-                root: testExtension.root,
+                name: testCachedExtension.name,
+                dist: path.join(path.join(envPaths().cache, EXTENSION_DIR_NAME), testCachedExtension.name),
+                main: testCachedExtension.main,
+                root: testCachedExtension.root,
                 official: false,
                 verification: EXTENSION_VERIFICATION_STATUS.UNSIGNED,
                 origin: EXTENSION_ORIGIN.CACHED,
-                type: testExtension.type,
-                version: testExtension.version,
+                type: testCachedExtension.type,
+                version: testCachedExtension.version,
             });
         });
 
         test('extension version list (online and cached versions)', async () => {
-            const extensionVersionList = (await extensionVersions.fetchExtensionVersions()).toArray();
+            const extensionVersionList = (await extensionVersions.fetchExtensionVersions())
+                .toArray()
+                .filter((ext) => ext.name.includes(testCachedExtension.name) || ext.name === TEST_EXTENSION);
 
             expect(extensionVersionList).toEqual([
                 {
-                    name: testExtension.name,
+                    name: testCachedExtension.name,
                     origin: EXTENSION_ORIGIN.CACHED,
-                    version: testExtension.version,
+                    version: testCachedExtension.version,
                 },
                 {
                     name: TEST_EXTENSION,

--- a/packages/common/src/utils/system/test-extensions.ts
+++ b/packages/common/src/utils/system/test-extensions.ts
@@ -5,7 +5,7 @@ import tar from 'tar';
 
 import {envPaths} from '../env-paths';
 import {IInstalledExtension} from '../../models';
-import {EXTENSION_DIR_NAME, EXTENSION_MANIFEST_FILE, EXTENSION_TYPES} from '../../constants';
+import {ENTITY_TYPES, EXTENSION_DIR_NAME, EXTENSION_MANIFEST_FILE, EXTENSION_TYPES} from '../../constants';
 
 export class TestExtensions {
     extensions: Array<IInstalledExtension | string> = [];
@@ -19,7 +19,10 @@ export class TestExtensions {
         return name;
     }
 
-    private async createExtension(type: EXTENSION_TYPES, extensionPath: string): Promise<IInstalledExtension> {
+    private async createExtension(type: EXTENSION_TYPES, cached?: boolean): Promise<IInstalledExtension> {
+        const extensionPath = cached
+            ? path.join(envPaths().cache, EXTENSION_DIR_NAME)
+            : path.join(envPaths().data, EXTENSION_DIR_NAME);
         const name = this.createName();
         const root = path.join(extensionPath, name);
         const manifest: IInstalledExtension = {
@@ -44,7 +47,7 @@ export class TestExtensions {
         await fse.writeJSON(manifestPath, manifest);
         await fse.writeJSON(packageJsonPath, packageJson);
 
-        if (type === EXTENSION_TYPES.STATIC) {
+        if (type === EXTENSION_TYPES.STATIC && !cached) {
             await fse.ensureDir(path.join(extensionPath, type));
             await fse.symlink(root, path.join(extensionPath, type, name), 'junction');
         }
@@ -56,7 +59,7 @@ export class TestExtensions {
 
     async cacheArchive(type: EXTENSION_TYPES = EXTENSION_TYPES.STATIC): Promise<IInstalledExtension> {
         const cachePath = path.join(envPaths().cache, EXTENSION_DIR_NAME);
-        const manifest = await this.createExtension(type, cachePath);
+        const manifest = await this.createExtension(type, true);
         const archivePath = path.join(cachePath, `${manifest.name}.tgz`);
 
         await tar.c(
@@ -75,15 +78,11 @@ export class TestExtensions {
     }
 
     cacheNew(type: EXTENSION_TYPES = EXTENSION_TYPES.STATIC): Promise<IInstalledExtension> {
-        const cachePath = path.join(envPaths().cache, EXTENSION_DIR_NAME);
-
-        return this.createExtension(type, cachePath);
+        return this.createExtension(type, true);
     }
 
     installNew(type: EXTENSION_TYPES = EXTENSION_TYPES.STATIC): Promise<IInstalledExtension> {
-        const installationPath = path.join(envPaths().data, EXTENSION_DIR_NAME);
-
-        return this.createExtension(type, installationPath);
+        return this.createExtension(type);
     }
 
     async teardown(): Promise<void> {
@@ -99,6 +98,10 @@ export class TestExtensions {
                     path.join(envPaths().cache, EXTENSION_DIR_NAME, `${ext.name}@${ext.version}`),
                     path.join(envPaths().data, EXTENSION_DIR_NAME, ext.name),
                     path.join(envPaths().data, EXTENSION_DIR_NAME, `${ext.name}@${ext.version}`),
+                    path.join(envPaths().data, EXTENSION_DIR_NAME, `${ENTITY_TYPES.EXTENSION}-${ext.name}`),
+                    ...Object.values(EXTENSION_TYPES).map((extType) =>
+                        path.join(envPaths().data, EXTENSION_DIR_NAME, extType, ext.name),
+                    ),
                 ].map((p) => fse.remove(p)),
             );
         });

--- a/packages/web/src/entities/extension/extension.e2e.ts
+++ b/packages/web/src/entities/extension/extension.e2e.ts
@@ -11,6 +11,8 @@ import {
     envPaths,
     PROJECTS_DIR_NAME,
     getAppLaunchUrl,
+    EXTENSION_ORIGIN,
+    EXTENSION_TYPES,
 } from '@relate/common';
 import fse from 'fs-extra';
 import path from 'path';
@@ -18,7 +20,7 @@ import path from 'path';
 import configuration from '../../configs/dev.config';
 import {WebModule} from '../../web.module';
 
-let TEST_DB_ID: string;
+let TEST_DBMS_ID: string;
 const TEST_ACCESS_TOKEN =
     // eslint-disable-next-line max-len
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NUb2tlbiI6eyJzY2hlbWUiOiJiYXNpYyIsInByaW5jaXBhbCI6Im5lbzRqIiwiY3JlZGVudGlhbHMiOiJleUo0TldNaU9sc2lUVWxKUmtocVEwTkJkMkZuUVhkSlFrRm5TVU5GUVZGM1JGRlpTa3R2V2tsb2RtTk9RVkZGVEVKUlFYZFRSRVZNVFVGclIwRXhWVVZDYUUxRFZUQlZlRVI2UVU1Q1owNVdRa0ZuVFVKc1RqTmFWMUpzWW1wRlUwMUNRVWRCTVZWRlEyZDNTbFJ0Vm5aT1IyOW5VMWMxYWsxU1VYZEZaMWxFVmxGUlJFUkJkRTlhVnpnd1lXbENTbUp1VW14amFrRmxSbmN3ZVUxRVFYbE5hbFYzVDBSQmQwNUVRbUZHZHpCNlRVUkJlVTFxU1hkUFJFRjNUa1JDWVUxR1JYaERla0ZLUW1kT1ZrSkJXVlJCYkU1R1RWRTRkMFJSV1VSV1VWRkpSRUZhVkdReVZtdGFWelI0UldwQlVVSm5UbFpDUVc5TlExVTFiR0o2VW5GSlJXeDFXWHBGWkUxQ2MwZEJNVlZGUVhkM1ZWUnRWblpPUjI5blVUSldlV1JEUWxkWlYzaHdXa2RHTUdJelNYZG5aMFZwVFVFd1IwTlRjVWRUU1dJelJGRkZRa0ZSVlVGQk5FbENSSGRCZDJkblJVdEJiMGxDUVZGRFhDOVFNMFppU0ZNNVNXOUllV3RjTDNSVk5sZ3liME5SZEVKTFMweElkbHBrZG5oTFpUVkZNbHBRVkZsTlYyWTRSMnRQVDB4Sk5FSjRUMHR2Wmt4UFRGbzVaVGRMTWxaaGNsa3pObkpHZVhKYWJrVmNMMXd2WjNjclVYbHlRVUpCUkRGaFlUVnlWRzVyYjB0NWNHdzBWM2x3ZVU5VGFGWkplbTlXVWswek1FY3diREJIVVhVcmRHaFlUMDVYTW01QlQwWlRWMjlZVm1ZMVJXSkVUMkZ3YWt0b2EwZFlUSFkzUkV4M2NIcFFPREV5ZDFaVFZUQTVkbVZJWkdScE1tdFNWVlpZYURkc05HRk9aRW9yZDI5NGJWZFBUbWcyVmpCUE1rRnFTMk5xTkd4UWEzTmlPWGx3Tmx3dldYZENNbkk1ZFhsYWJHMUlTMmxGUm5OVk1XVllXWGQxU0U5R01XdE9iVk5qWkZScWRIbFpkMUJjTDB4dlhDOUhkakI1T1VSbU5EWnZlSE52ZEhCb1drNTNRMHhSWkdkVVFXWkRkR2hrYkZvemFEUmFaVTlqYUhKelVqSklhMlpjTDBSRVZtVkJkWGRTWWxJeWVqSkdaaXRuTVVGblRVSkJRVWRxWjJkRlNFMUpTVUpCZWtGS1FtZE9Wa2hTVFVWQmFrRkJUVUpGUjBOWFEwZFRRVWRISzBWSlFrRlJVVVZCZDBsR2IwUkJla0puYkdkb2EyZENhSFpvUTBGUk1FVkthRmxyVkROQ2JHSnNUbFJVUTBKSVdsYzFiR050UmpCYVYxRm5VVEo0Y0ZwWE5UQkpSVTVzWTI1U2NGcHRiR3BaV0ZKc1RVSXdSMEV4VldSRVoxRlhRa0pTUTNKMWVHbFJiVTVNU1VJNGJXRkRlVXBsWlZCclpHTjRlbXRVUVdaQ1owNVdTRk5OUlVkRVFWZG5RbFI2Y0RReWFtd3pNR3RDVFhoQ1IweHZPV0kxVGxSaWVDdElOa1JCVDBKblRsWklVVGhDUVdZNFJVSkJUVU5DWlVGM1NGRlpSRlpTTUd4Q1FsbDNSa0ZaU1V0M1dVSkNVVlZJUVhkSlIwTkRjMGRCVVZWR1FuZE5SVTFFT0VkQk1WVmtTSGRSTkUxRVdYZE9TMEY1YjBSRFIweHRhREJrU0VFMlRIazVjMkl5VG1oaVIyaDJZek5STms1cVFYZE5RemxxWTIxM2RtRlhOVEJhV0VwMFdsZFNjRmxZVW14TWJVNTVZa00xZDFwWE1IZEVVVmxLUzI5YVNXaDJZMDVCVVVWTVFsRkJSR2RuU1VKQlJIWjZTbXhyUWpGWFpucFNTRmRQZUhOUmVFNU1VRzFhVkZadFFsZzVUREJtYldaVU4xQkNibkJLZUhoV1dsUkhaR016YWxkamQyOUpURGhIVkU5bk9XaDFjRnBSTlhscVJ6ZFhhMW8xYjI4NE5XUmtRMmt6Ukc4eFYxQllZMnRCTkZFd2VVTlFOVFJpYjNaY0wzbGFiakJOVURjd1p6ZzJaM04yYlVONFkxa3hWV2hGUTJoVmQxd3ZUV2gwU0ZGTWFFbERia0pwVGtWRVFuWTRSWFpsUjB3M2FWTklSMXBvWEM5NlpHVlliVWxzY0c5MGVUa3JOMkpRU2paS1RuTlZUWFUwT0ROVFZGZFJjbVJTYmxSaFZXOXlRbmRzUkU5Q2ExVmxkWEJjTHpCb1NtdERPR3g0VEcwNFZuaDZhbWh0VEc0MU4xQlFXVzVQVFdOUlVYTklSRFF3VWpSYVozUnJObmxzUzIweFVXSjFNbWwzVGpJd1pHSTJaRmNyUTNGSVpVUndSemxZU0hWVVhDOXpiRVJFTjBOblZIVktZVkZhVlVkSk1XRjBWa2MwUm5CSWRrRXdlbWs0TWxwV1RsUnRNM0ZsVG1FemFFMW9iemhFWkRoVlZrVmFOalJYVVZVME5HRlBiMXd2ZFVwSllrMTZRV2NyT0ZSUFlsWjFhRXRvYTFKMGRreG9UMW8yUjBZeVpUVmtLM2xHZFhGMVQyRjVVbEZKTTA4d1NrWjRibE5VWWtSRGJWaFNPVlYwT0U1UloyeGpTVzVOUW5OYVMzUldhSGxKUlU5MFpWWnNZM1ZVZVhwSFlVOUljR1pjTDJoQk0wbEtaMWg1YW01RVZIcFZTbFJJUmxkM1kzRm9kamN3VDFCa1ZVcG5NRmRrZDFaRVRUUjZNR3h0YTJKbVMwZEJORlp3YW1kU2NYUnBZVGR4VTJsMWN6VlJPRFJtZFZORVFUZFNPVEJJYjBaY0wxaENSSFZYV1hsemNteE1TMXd2Y2tSS1kwZEtVbE5rYTJ0eU1tZG1lV0YxU2x3dmR6QnpaRGw1WlhKb1NrcE9TemNyZVhSelQxbGNMM1Z6VVRkak16Wm9Ra2N4WjNWQ00yNU9SMU5IUlhVeGVreGxkRUZWZHpWdVdXUkZSRFZHYnpaYWMzWjFUSFJGUkRoQlZVZFlaRVp4U1V4WldUTkxXSFpEUm14UlFuRjJRM2hpZEhreWNEZzJTMFZrZFZWbUt5SmRMQ0owZVhBaU9pSktWMVFpTENKaGJHY2lPaUpTVXpVeE1pSjkuZXlKaGRXUWlPaUppYkc5dmJTSXNJbTVpWmlJNk1UVTROVGd6TWpreE1pd2ljMk52Y0dVaU9sc2lZV1J0YVc0aVhTd2lhWE56SWpvaWJtVnZOR29pTENKbWJHRm5jeUk2VzEwc0ltVjRjQ0k2TVRVNE9EUXlORGt4TWl3aWFXRjBJam94TlRnMU9ETXlPVEV5TENKcWRHa2lPaUl6VGxsM2JtczBlaUlzSW5WelpYSnVZVzFsSWpvaWJtVnZOR29pZlEuU0RqSEItWXI1a3JROVJvdmxsaGtIM1kycVJQMzlOQy1kanZfYzdna0x1UXpKcmVueDY5RVY5MUxxYThUYnM0V0NjWDNFU2Q0MW1wUkdvbXVjR01LY0lON190Qm03SE5weXBVam03MlJaWHAyWlM5b0hTb1V4WndVekg3OFVvbHdJUHFuLXd5Vk9iWmxBRURzNnBfYmdSOGpNc1Z4X1g1bnhhT0FmLVVUY2J5WGVGOVgxbkVXMFd1TnN3T0N0WjZpZm9qSi1xbzRkWEI3eGNiMWQ1MnptVDFvZGZQdzBPXzRoTFNTZU81NWIwZ3g4OXZTMmJBUWYtNmpFSEZ0eVlJeFA1b05kWUZQa20yUkVlYkI2elZTWWV2ZzI5dDBOYzJRYUlxSVhtcU04OTNGRS1CeWQ2NlUwalphM2F5WmdQZXNBMll6dG85ZFRaNVhBY2FRR1pwMkJRIn0sImFjY291bnRJZCI6ImZvbyIsImFwcElkIjoiYmxvb20iLCJkYm1zSWQiOiJib20iLCJpYXQiOjE1ODU4MzMwODEsImV4cCI6MTU4NTkxOTQ4MX0.72dX69CwV9KJHZA9kz2n1ruwSx7znvM7uJjmvLZAF8w';
@@ -87,11 +89,19 @@ describe('AppsModule', () => {
     let testExtension: IInstalledExtension;
     let testEnvironment: Environment;
 
+    const queryBody = (query: string, variables?: {[key: string]: any}): {[key: string]: any} => ({
+        query,
+        variables: {
+            environmentNameOrId: dbmss.environment.id,
+            ...variables,
+        },
+    });
+
     beforeAll(async () => {
         dbmss = await TestDbmss.init(__filename);
         const {id} = await dbmss.createDbms();
         testEnvironment = dbmss.environment;
-        TEST_DB_ID = id;
+        TEST_DBMS_ID = id;
         testExtension = await extensions.installNew();
 
         const module = await Test.createTestingModule({
@@ -122,7 +132,7 @@ describe('AppsModule', () => {
                 variables: {
                     ...CREATE_APP_LAUNCH_TOKEN.variables,
                     accessToken: TEST_ACCESS_TOKEN,
-                    dbmsId: TEST_DB_ID,
+                    dbmsId: TEST_DBMS_ID,
                     appName: testExtension.name,
                     projectId: TEST_PROJECT_ID,
                 },
@@ -143,7 +153,7 @@ describe('AppsModule', () => {
         const {principal} = CREATE_APP_LAUNCH_TOKEN.variables;
         const launchToken = await testEnvironment.extensions.createAppLaunchToken(
             testExtension.name,
-            TEST_DB_ID,
+            TEST_DBMS_ID,
             principal,
             TEST_ACCESS_TOKEN,
             TEST_PROJECT_ID,
@@ -172,7 +182,7 @@ describe('AppsModule', () => {
                         accessToken: CREATE_APP_LAUNCH_TOKEN.variables.accessToken,
                         appName: testExtension.name,
                         dbms: {
-                            id: TEST_DB_ID,
+                            id: TEST_DBMS_ID,
                         },
                         environmentId: expect.any(String),
                         principal: CREATE_APP_LAUNCH_TOKEN.variables.principal,
@@ -182,5 +192,107 @@ describe('AppsModule', () => {
                     });
                 })
         );
+    });
+
+    test('/graphql listExtensions', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `query ListExtensions($environmentNameOrId: String) {
+                    listExtensions(environmentNameOrId: $environmentNameOrId) {
+                        name
+                        version
+                        type
+                        origin
+                    }
+                }`,
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {listExtensions} = res.body.data;
+
+                expect(listExtensions.length).toBeGreaterThanOrEqual(1);
+                expect(listExtensions).toContainEqual({
+                    name: testExtension.name,
+                    version: testExtension.version,
+                    type: testExtension.type,
+                    origin: EXTENSION_ORIGIN.CACHED,
+                });
+            });
+    });
+
+    test('/graphql uninstallExtension', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `mutation UninstallExtension($environmentNameOrId: String, $name: String!) {
+                            uninstallExtension(environmentNameOrId: $environmentNameOrId, name: $name) {
+                                name
+                                version
+                                type
+                                origin
+                            }
+                        }`,
+                    {
+                        name: testExtension.name,
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {uninstallExtension} = res.body.data;
+
+                expect(uninstallExtension).toHaveLength(1);
+                expect(uninstallExtension[0]).toEqual({
+                    name: testExtension.name,
+                    version: testExtension.version,
+                    type: testExtension.type,
+                    origin: EXTENSION_ORIGIN.CACHED,
+                });
+            });
+    });
+
+    test('/graphql installExtension', async () => {
+        const testExtensionDist = await extensions.cacheNew(EXTENSION_TYPES.STATIC);
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `mutation InstallExtension(
+                        $environmentNameOrId: String,
+                        $name: String!,
+                        $version: String!
+                    ) {
+                        installExtension(
+                            environmentNameOrId: $environmentNameOrId,
+                            name: $name,
+                            version: $version
+                        ) {
+                            name
+                            version
+                            type
+                            origin
+                        }
+                    }`,
+                    {
+                        name: testExtensionDist.name,
+                        version: testExtensionDist.version,
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {installExtension} = res.body.data;
+
+                expect(installExtension).toEqual({
+                    name: testExtensionDist.name,
+                    version: testExtensionDist.version,
+                    type: testExtensionDist.type,
+                    origin: EXTENSION_ORIGIN.CACHED,
+                });
+            });
     });
 });

--- a/packages/web/src/entities/extension/extension.resolver.ts
+++ b/packages/web/src/entities/extension/extension.resolver.ts
@@ -95,8 +95,6 @@ export class ExtensionResolver {
         };
     }
 
-    // @todo: need to add tests here and in common for:
-    // INSTALL_EXTENSION, UNINSTALL_EXTENSION, LIST_EXTENSION_VERSIONS, INSTALLED_EXTENSIONS
     @Mutation(() => AppData)
     async [PUBLIC_GRAPHQL_METHODS.INSTALL_EXTENSION](
         @Context('environment') environment: Environment,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Replica of https://github.com/neo4j-devtools/relate/pull/152 (was created before the repo switch over and it seems to have lost context)
- have had to add filtering to check the the test extensions names include `path.basename(__filename)`, for example, as there didnt seem to be a guarantee of what can be in fixtures directory at any moment in time - was causing a lots of flaky test failures on builds otherwise.

### What is the current behavior?
(You can also link to an open issue here)


### What is the new behavior?
(if this is a feature change)


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)


### Other information:
