### PR TITLE
Feature remote STATIC extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "eslint . --ext .ts",
         "test:teardown": "node scripts/tests/teardown.js",
         "test:setup": "node scripts/tests/setup.js",
-        "lerna:test": "lerna run test",
+        "lerna:test": "lerna run test --concurrency 1",
         "test": "run-s --continue-on-error test:setup lerna:test test:teardown",
         "test:pr": "run-s lint test",
         "lerna:clean": "lerna clean -y",

--- a/packages/cli/src/modules/app/app.e2e.ts
+++ b/packages/cli/src/modules/app/app.e2e.ts
@@ -5,7 +5,7 @@ import AccessTokenCommand from '../../commands/dbms/access-token';
 import OpenCommand from '../../commands/app/open';
 import StartCommand from '../../commands/dbms/start';
 
-const appRoot = 'fakeRoot';
+const appRoot = '/fakeRoot';
 
 jest.mock('cli-ux', () => {
     return {

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -6,6 +6,22 @@ type GraphQLQuery = {
     query: string;
 };
 
+type RelateURLParams = {
+    relateUrl: string | null;
+    relateLaunchToken: string | null;
+    relateApiToken: string | null;
+};
+
+export function getURLParameters(url: string): RelateURLParams {
+    const queryParam = new URL(url).searchParams;
+
+    return {
+        relateUrl: queryParam.get('relateUrl'),
+        relateLaunchToken: queryParam.get('relateLaunchToken'),
+        relateApiToken: queryParam.get('relateApiToken'),
+    };
+}
+
 export function getParseLaunchTokenPayload(appName: string, launchToken: string): GraphQLQuery {
     const operationName = 'launchData';
 

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -191,3 +191,7 @@ export enum EXTENSION_VERIFICATION_STATUS {
     UNTRUSTED = 'UNTRUSTED',
     REVOKED = 'REVOKED',
 }
+
+export const RELATE_URL_PARAM_NAME = 'relateUrl';
+export const RELATE_API_TOKEN_PARAM_NAME = 'relateApiToken';
+export const RELATE_LAUNCH_TOKEN_PARAM_NAME = 'relateLaunchToken';

--- a/packages/common/src/entities/extensions/extensions.local.ts
+++ b/packages/common/src/entities/extensions/extensions.local.ts
@@ -34,7 +34,7 @@ export class LocalExtensions extends ExtensionsAbstract<LocalEnvironment> {
     async getAppPath(appName: string, appRoot = ''): Promise<string> {
         const appBase = await getAppBasePath(appName);
 
-        return `${appRoot}${appBase}`;
+        return isValidUrl(appBase) ? appBase : `${appRoot}${appBase}`;
     }
 
     async versions(filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IExtensionVersion>> {
@@ -160,7 +160,7 @@ export class LocalExtensions extends ExtensionsAbstract<LocalEnvironment> {
 
         await fse.copy(extractedDistPath, target);
 
-        if (extension.type === EXTENSION_TYPES.STATIC) {
+        if (extension.type === EXTENSION_TYPES.STATIC && !isValidUrl(extension.main)) {
             const staticTarget = path.join(this.environment.dirPaths.staticExtensionsData, extension.name);
 
             await fse.symlink(target, staticTarget, 'junction');
@@ -198,7 +198,7 @@ export class LocalExtensions extends ExtensionsAbstract<LocalEnvironment> {
             .mapEach(async (ext) => {
                 await fse.remove(ext.dist);
 
-                if (ext.type === EXTENSION_TYPES.STATIC) {
+                if (ext.type === EXTENSION_TYPES.STATIC && !isValidUrl(ext.main)) {
                     const staticTarget = path.join(this.environment.dirPaths.staticExtensionsData, ext.name);
 
                     await fse.remove(staticTarget);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,6 +1,6 @@
 export {IAuthToken} from '@huboneo/tapestry';
 // @todo: better way of handling types
-export {IExtensionVersion, loadExtensionsFor} from './utils/extensions';
+export {IExtensionVersion, loadExtensionsFor, getAppLaunchUrl} from './utils/extensions';
 export {TestDbmss, TestExtensions} from './utils/system';
 export * from './system';
 export * from './models';

--- a/packages/common/src/utils/extensions/get-app-base-path.ts
+++ b/packages/common/src/utils/extensions/get-app-base-path.ts
@@ -4,6 +4,7 @@ import {getInstalledExtensionsSync} from './get-installed-extensions';
 import {EXTENSION_TYPES} from '../../constants';
 import {NotFoundError} from '../../errors/not-found.error';
 import {discoverExtension} from './extension-versions';
+import {isValidUrl} from '../generic';
 
 export async function getAppBasePath(appName: string): Promise<string> {
     const installed = getInstalledExtensionsSync();
@@ -15,6 +16,10 @@ export async function getAppBasePath(appName: string): Promise<string> {
 
     const {name, main: mainExtension} = await discoverExtension(app.root);
     const appBase = `/${name}`;
+
+    if (isValidUrl(mainExtension)) {
+        return mainExtension;
+    }
 
     return Str.from(mainExtension)
         .map((main) => (main.startsWith('.') ? main.substr(1) : main))

--- a/packages/common/src/utils/extensions/get-app-launch-url.ts
+++ b/packages/common/src/utils/extensions/get-app-launch-url.ts
@@ -1,5 +1,6 @@
 import {EnvironmentAbstract} from '../../entities/environments';
 import {isValidUrl} from '../generic';
+import {RELATE_API_TOKEN_PARAM_NAME, RELATE_LAUNCH_TOKEN_PARAM_NAME, RELATE_URL_PARAM_NAME} from '../../constants';
 
 export async function getAppLaunchUrl(
     environment: EnvironmentAbstract,
@@ -10,15 +11,18 @@ export async function getAppLaunchUrl(
     const asURL = isValidUrl(appPath) ? new URL(appPath) : new URL(`${environment.httpOrigin}${appPath}`);
 
     if (asURL.origin !== environment.httpOrigin) {
-        asURL.searchParams.set('relateUrl', environment.httpOrigin);
+        asURL.searchParams.set(RELATE_URL_PARAM_NAME, environment.httpOrigin);
     }
 
     if (environment.requiresAPIToken) {
-        asURL.searchParams.set('relateApiToken', await environment.generateAPIToken(asURL.host, clientId, {}));
+        asURL.searchParams.set(
+            RELATE_API_TOKEN_PARAM_NAME,
+            await environment.generateAPIToken(asURL.host, clientId, {}),
+        );
     }
 
     if (launchToken) {
-        asURL.searchParams.set('relateLaunchToken', launchToken);
+        asURL.searchParams.set(RELATE_LAUNCH_TOKEN_PARAM_NAME, launchToken);
     }
 
     return `${asURL}`;

--- a/packages/common/src/utils/extensions/get-app-launch-url.ts
+++ b/packages/common/src/utils/extensions/get-app-launch-url.ts
@@ -1,0 +1,25 @@
+import {EnvironmentAbstract} from '../../entities/environments';
+import {isValidUrl} from '../generic';
+
+export async function getAppLaunchUrl(
+    environment: EnvironmentAbstract,
+    appPath: string,
+    clientId: string,
+    launchToken?: string,
+): Promise<string> {
+    const asURL = isValidUrl(appPath) ? new URL(appPath) : new URL(`${environment.httpOrigin}${appPath}`);
+
+    if (asURL.origin !== environment.httpOrigin) {
+        asURL.searchParams.set('relateUrl', environment.httpOrigin);
+    }
+
+    if (environment.requiresAPIToken) {
+        asURL.searchParams.set('relateApiToken', await environment.generateAPIToken(asURL.host, clientId, {}));
+    }
+
+    if (launchToken) {
+        asURL.searchParams.set('relateLaunchToken', launchToken);
+    }
+
+    return `${asURL}`;
+}

--- a/packages/common/src/utils/extensions/index.ts
+++ b/packages/common/src/utils/extensions/index.ts
@@ -2,5 +2,6 @@ export * from './extension-versions';
 export * from './extract-extension';
 export * from './download-extension';
 export * from './get-app-base-path';
+export * from './get-app-launch-url';
 export {getInstalledExtensionsSync} from './get-installed-extensions';
 export {loadExtensionsFor} from './load-extensions-for';

--- a/packages/common/src/utils/generic/is-valid-url.ts
+++ b/packages/common/src/utils/generic/is-valid-url.ts
@@ -1,10 +1,8 @@
 export const isValidUrl = (stringVal: string): boolean => {
     try {
         const url = new URL(stringVal);
-        if (['http:', 'https:'].includes(url.protocol)) {
-            return true;
-        }
-        return false;
+
+        return ['http:', 'https:'].includes(url.protocol);
     } catch (_) {
         return false;
     }

--- a/packages/electron/src/window/window.module.ts
+++ b/packages/electron/src/window/window.module.ts
@@ -5,6 +5,7 @@ import {
     Environment,
     ENVIRONMENT_TYPES,
     emitHookEvent,
+    getAppLaunchUrl,
     HOOK_EVENTS,
     NotFoundError,
     SystemModule,
@@ -34,9 +35,10 @@ export class WindowModule {
         const httpOrigin = this.getHttpOrigin(environment);
         const appRoot = await this.getAppRoot(httpOrigin);
         const appPath = await environment.extensions.getAppPath(appName, appRoot);
+        const appUrl = await getAppLaunchUrl(environment, appPath, appName);
 
         // and load the index.html of the app.
-        mainWindow.loadURL(`${httpOrigin}${appPath}`);
+        mainWindow.loadURL(appUrl);
     }
 
     private async getAppRoot(httpOrigin: string): Promise<string> {

--- a/packages/web/src/entities/extension/extension.constants.ts
+++ b/packages/web/src/entities/extension/extension.constants.ts
@@ -1,1 +1,0 @@
-export const LAUNCH_TOKEN_PARAMETER: '_appLaunchToken' = '_appLaunchToken';

--- a/packages/web/src/entities/extension/extension.e2e.ts
+++ b/packages/web/src/entities/extension/extension.e2e.ts
@@ -43,7 +43,7 @@ const CREATE_APP_LAUNCH_TOKEN = {
                 projectId: $projectId,
             ) {
                 token
-                path
+                url
             }
         }
     `,
@@ -130,7 +130,7 @@ describe('AppsModule', () => {
             .expect(HTTP_OK)
             .expect(async (res: request.Response) => {
                 const {createAppLaunchToken = {}} = res.body.data;
-                const {token, path: tokenPath} = createAppLaunchToken;
+                const {token, url: tokenPath} = createAppLaunchToken;
                 const appUrl = `${testEnvironment.httpOrigin}${STATIC_APP_BASE_ENDPOINT}/${testExtension.name}/`;
                 const expectedPath = await getAppLaunchUrl(testEnvironment, appUrl, testExtension.name, token);
 

--- a/packages/web/src/entities/extension/extension.e2e.ts
+++ b/packages/web/src/entities/extension/extension.e2e.ts
@@ -10,13 +10,13 @@ import {
     STATIC_APP_BASE_ENDPOINT,
     envPaths,
     PROJECTS_DIR_NAME,
+    getAppLaunchUrl,
 } from '@relate/common';
 import fse from 'fs-extra';
 import path from 'path';
 
 import configuration from '../../configs/dev.config';
 import {WebModule} from '../../web.module';
-import {createAppLaunchUrl} from './extension.utils';
 
 let TEST_DB_ID: string;
 const TEST_ACCESS_TOKEN =
@@ -128,10 +128,11 @@ describe('AppsModule', () => {
                 },
             })
             .expect(HTTP_OK)
-            .expect((res: request.Response) => {
+            .expect(async (res: request.Response) => {
                 const {createAppLaunchToken = {}} = res.body.data;
                 const {token, path: tokenPath} = createAppLaunchToken;
-                const expectedPath = createAppLaunchUrl(`${STATIC_APP_BASE_ENDPOINT}/${testExtension.name}/`, token);
+                const appUrl = `${testEnvironment.httpOrigin}${STATIC_APP_BASE_ENDPOINT}/${testExtension.name}/`;
+                const expectedPath = await getAppLaunchUrl(testEnvironment, appUrl, testExtension.name, token);
 
                 expect(token).toEqual(expect.stringMatching(JWT_REGEX));
                 expect(tokenPath).toEqual(expectedPath);

--- a/packages/web/src/entities/extension/extension.types.ts
+++ b/packages/web/src/entities/extension/extension.types.ts
@@ -22,7 +22,7 @@ export class ExtensionData {
 @ObjectType()
 export class AppData extends ExtensionData {
     @Field(() => String)
-    path!: string;
+    url!: string;
 }
 
 @ObjectType()
@@ -52,7 +52,7 @@ export class AppLaunchToken {
     token: string;
 
     @Field(() => String)
-    path: string;
+    url: string;
 }
 
 @ArgsType()

--- a/packages/web/src/entities/extension/extension.utils.ts
+++ b/packages/web/src/entities/extension/extension.utils.ts
@@ -1,5 +1,0 @@
-import {LAUNCH_TOKEN_PARAMETER} from './extension.constants';
-
-export function createAppLaunchUrl(appRoot: string, launchToken?: string): string {
-    return launchToken ? `${appRoot}?${LAUNCH_TOKEN_PARAMETER}=${launchToken}` : appRoot;
-}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
This PR adds support for using remote apps, defined as an installed STATIC extension whose `main` property contains a URL.

This PR also updates various URL parameters used by relate to match those of Neo4j Desktop, and exposes a new client utility for grabbing them from URLs.

Further this PR changes the GraphQL schema for apps to include a `url` property instead of a `path`.


### What is the current behavior?
Can only open locally installed apps


### What is the new behavior?
Apps can point to a URL


### Does this PR introduce a breaking change?
yes, this PR changes the GraphQL schema for apps to include a `url` property instead of a `path`.


### Other information:
Sample remote app:
```json
{
  "name": "gewgle",
  "version": "1.0.1",
  "main": "https://google.com"
}
```
[extension-gewgle.zip](https://github.com/neo4j-devtools/relate/files/5458309/extension-gewgle.zip)

CLI Usage
```
$ relate app:open gewgle -L
> https://google.com/?relateUrl=http%3A%2F%2F127.0.0.1%3A3000
```

WEB Usage
<img width="1505" alt="Screenshot 2020-10-29 at 13 32 57" src="https://user-images.githubusercontent.com/52443771/97574281-458fe800-19eb-11eb-9d08-114427c177d4.png">
