### PR TITLE
Add xvfb script for Docker tests

### DIFF
--- a/scripts/tests/setup.js
+++ b/scripts/tests/setup.js
@@ -41,28 +41,32 @@ async function populateDistributionCache(env) {
         // the cached directory we get during installation.
 
         const spinner = ora(`Caching Neo4j ${version}`).start();
-        await env.dbmss.install(
-            `global-setup-${version}`,
-            version,
-            TestDbmss.NEO4J_EDITION,
-            TestDbmss.DBMS_CREDENTIALS,
-            false,
-        );
-        await env.dbmss.uninstall(`global-setup-${version}`);
+
+        try {
+            await env.dbmss.install(
+                `global-setup-${version}`,
+                version,
+                TestDbmss.NEO4J_EDITION,
+                TestDbmss.DBMS_CREDENTIALS,
+                false,
+            );
+            await env.dbmss.uninstall(`global-setup-${version}`);
+        } catch (err) {
+            spinner.fail(err.message);
+            throw err;
+        }
         spinner.succeed();
     }
 }
 
 async function globalSetup() {
-
-    const spinner = ora(`Preparing environment`).start();
+    console.log('Preparing environment');
     await fse.emptyDir(envPaths().data);
     await fse.ensureFile(path.join(envPaths().data, '.GITIGNORED'));
     await fse.ensureFile(path.join(envPaths().cache, '.GITIGNORED'));
     await fse.ensureFile(path.join(envPaths().data, 'acceptedTerms'));
 
     const env = (await TestDbmss.init('relate')).environment;
-    spinner.succeed();
 
     await populateDistributionCache(env);
 
@@ -89,5 +93,5 @@ async function globalSetup() {
     );
 }
 
-console.log("Setting up tests");
+console.log('Setting up tests');
 globalSetup().then(() => console.log('Setup complete'));

--- a/scripts/tests/xvfb.sh
+++ b/scripts/tests/xvfb.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# USAGE
+#   source ./xvfb.sh [COMMAND]
+#
+# DESCRIPTION
+#   This script should be used before and after running Electron tests in
+#   Docker. It starts a display server that implements the X11 protocol without
+#   actually showing screen output. It then sets environment variables to point
+#   applications to it and to start Electron processes with Chromium sandboxing
+#   disabled.
+#
+# COMMANDS
+#   setup       start xvfb and set environments variables
+#   teardown    stop xvfb
+#
+
+case $1 in
+setup)
+    Xvfb :99 -ac -screen 0 1280x720x16 -nolisten tcp &
+    export XVFB_PID=$!
+    export DISPLAY=:99
+
+    # https://github.com/electron/electron/issues/17972#issuecomment-516957971
+    # https://github.com/electron/electron/pull/16576
+    export ELECTRON_DISABLE_SANDBOX=true
+    ;;
+teardown)
+    kill $XVFB_PID
+    wait $XVFB_PID
+    ;;
+esac


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Allows tests to be run in Docker.


### What is the current behavior?
We can't run tests in Docker because the Electron tests hang indefinitely when no display server is available.


### What is the new behavior?
We can now call a script to setup up and teardown an in-memory display server that is needed to run Electron tests in Docker.


### Does this PR introduce a breaking change?
No


### Other information:
