### PR TITLE
Add server status to infoDbmss, make all CLI flags camel case

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,7 +20,7 @@ $ npm install -g @relate/cli
 $ relate COMMAND
 running command...
 $ relate (-v|--version|version)
-@relate/cli/1.0.2-alpha.15 darwin-x64 node-v12.18.3
+@relate/cli/1.0.2-alpha.15 linux-x64 node-v12.16.1
 $ relate --help [COMMAND]
 USAGE
   $ relate COMMAND

--- a/packages/cli/docs/app.md
+++ b/packages/cli/docs/app.md
@@ -31,4 +31,4 @@ EXAMPLES
   $ relate app:open app-name -D dbms-to-connect-to -e environment-name -L
 ```
 
-_See code: [dist/commands/app/open.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/app/open.ts)_
+_See code: [dist/commands/app/open.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/app/open.ts)_

--- a/packages/cli/docs/backup.md
+++ b/packages/cli/docs/backup.md
@@ -29,7 +29,7 @@ EXAMPLES
   $ relate backup:create <entity-id> -t dbms
 ```
 
-_See code: [dist/commands/backup/create.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/backup/create.ts)_
+_See code: [dist/commands/backup/create.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/backup/create.ts)_
 
 ## `relate backup:list`
 
@@ -56,7 +56,7 @@ EXAMPLES
   $ relate backup:list --sort=created
 ```
 
-_See code: [dist/commands/backup/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/backup/list.ts)_
+_See code: [dist/commands/backup/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/backup/list.ts)_
 
 ## `relate backup:remove BACKUPID`
 
@@ -77,7 +77,7 @@ EXAMPLES
   $ relate backup:remove -e environment-name
 ```
 
-_See code: [dist/commands/backup/remove.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/backup/remove.ts)_
+_See code: [dist/commands/backup/remove.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/backup/remove.ts)_
 
 ## `relate backup:restore BACKUPIDORPATH [OUTPUTPATH]`
 
@@ -100,4 +100,4 @@ EXAMPLES
   $ relate backup:restore <backup-id-or-path> <output-path>
 ```
 
-_See code: [dist/commands/backup/restore.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/backup/restore.ts)_
+_See code: [dist/commands/backup/restore.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/backup/restore.ts)_

--- a/packages/cli/docs/db.md
+++ b/packages/cli/docs/db.md
@@ -37,7 +37,7 @@ EXAMPLES
   $ relate db:create my-new-db -D started-dbms -u dbms-user-with-system-db-access
 ```
 
-_See code: [dist/commands/db/create.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/db/create.ts)_
+_See code: [dist/commands/db/create.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/db/create.ts)_
 
 ## `relate db:drop [NAME]`
 
@@ -66,7 +66,7 @@ EXAMPLES
   $ relate db:drop my-new-db -D started-dbms -u dbms-user-with-system-db-access
 ```
 
-_See code: [dist/commands/db/drop.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/db/drop.ts)_
+_See code: [dist/commands/db/drop.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/db/drop.ts)_
 
 ## `relate db:dump DBMS`
 
@@ -91,7 +91,7 @@ EXAMPLES
   $ relate db:dump dbms-containing-db-to-dump -d db-to-dump -t /path/to/save/dump/file/to
 ```
 
-_See code: [dist/commands/db/dump.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/db/dump.ts)_
+_See code: [dist/commands/db/dump.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/db/dump.ts)_
 
 ## `relate db:exec DBMS`
 
@@ -117,7 +117,7 @@ EXAMPLES
   $ relate db:exec dbms-containing-db-to-query -f /path/to/cypher/file -d db-to-query --force
 ```
 
-_See code: [dist/commands/db/exec.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/db/exec.ts)_
+_See code: [dist/commands/db/exec.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/db/exec.ts)_
 
 ## `relate db:list`
 
@@ -157,7 +157,7 @@ EXAMPLES
   $ relate db:list --filter=name=db-name --output=json
 ```
 
-_See code: [dist/commands/db/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/db/list.ts)_
+_See code: [dist/commands/db/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/db/list.ts)_
 
 ## `relate db:load DBMS`
 
@@ -183,4 +183,4 @@ EXAMPLES
   $ relate db:load dbms-containing-db-to-load-into -f /path/to/dump/file -d db-to-load-into --force
 ```
 
-_See code: [dist/commands/db/load.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/db/load.ts)_
+_See code: [dist/commands/db/load.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/db/load.ts)_

--- a/packages/cli/docs/dbms.md
+++ b/packages/cli/docs/dbms.md
@@ -79,6 +79,7 @@ OPTIONS
   --filter=filter                filter property by partial string matching, ex: name=foo
   --no-header                    hide table header from output
   --no-truncate                  do not truncate output to fit screen
+  --onlineCheck                  Check if the DBMS is online
   --output=csv|json|yaml         output in a more machine friendly format
   --sort=sort                    property to sort by (prepend '-' for descending)
 
@@ -108,7 +109,7 @@ OPTIONS
   -e, --environment=environment  Name of the environment to run the command against
   -n, --name=name                (required) Name to give the newly installed DBMS
   --limited                      Display limited versions of DBMSs
-  --no-caching                   Prevent caching of the downloaded DBMS
+  --noCaching                    Prevent caching of the downloaded DBMS
 
 EXAMPLES
   $ relate dbms:install
@@ -294,8 +295,8 @@ ARGUMENTS
 OPTIONS
   -e, --environment=environment  Name of the environment to run the command against
   -v, --version=version          (required) Version to install (semver, url, or path)
-  --no-caching                   Prevent caching of the downloaded DBMS
-  --no-migration                 Prevent migrating the data to new formats
+  --noCaching                    Prevent caching of the downloaded DBMS
+  --noMigration                  Prevent migrating the data to new formats
 
 EXAMPLES
   $ relate dbms:upgrade

--- a/packages/cli/docs/dbms.md
+++ b/packages/cli/docs/dbms.md
@@ -38,7 +38,7 @@ EXAMPLES
   $ relate dbms:access-token my-dbms -u dbms-user
 ```
 
-_See code: [dist/commands/dbms/access-token.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/access-token.ts)_
+_See code: [dist/commands/dbms/access-token.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/access-token.ts)_
 
 ## `relate dbms:add-tag DBMS TAGNAME`
 
@@ -59,7 +59,7 @@ EXAMPLE
   $ relate dbms:add-tag dbmsId "production"
 ```
 
-_See code: [dist/commands/dbms/add-tag.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/add-tag.ts)_
+_See code: [dist/commands/dbms/add-tag.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/add-tag.ts)_
 
 ## `relate dbms:info [DBMSS]`
 
@@ -92,7 +92,7 @@ EXAMPLES
   $ relate dbms:info --filter=name=my-dbms --output=json
 ```
 
-_See code: [dist/commands/dbms/info.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/info.ts)_
+_See code: [dist/commands/dbms/info.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/info.ts)_
 
 ## `relate dbms:install VERSION`
 
@@ -119,7 +119,7 @@ EXAMPLES
   $ relate dbms:install 4.0.2 -n my-new-dbms -e environment-name --no-caching
 ```
 
-_See code: [dist/commands/dbms/install.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/install.ts)_
+_See code: [dist/commands/dbms/install.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/install.ts)_
 
 ## `relate dbms:link FILEPATH DBMSNAME`
 
@@ -139,7 +139,7 @@ EXAMPLE
   $ relate dbms:link /path/to/target/dbms/dir "related DBMS"
 ```
 
-_See code: [dist/commands/dbms/link.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/link.ts)_
+_See code: [dist/commands/dbms/link.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/link.ts)_
 
 ## `relate dbms:list`
 
@@ -166,7 +166,7 @@ EXAMPLES
   $ relate dbms:list --filter=name=my-dbms --output=json
 ```
 
-_See code: [dist/commands/dbms/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/list.ts)_
+_See code: [dist/commands/dbms/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/list.ts)_
 
 ## `relate dbms:open DBMS`
 
@@ -189,7 +189,7 @@ EXAMPLES
   $ relate dbms:open -L
 ```
 
-_See code: [dist/commands/dbms/open.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/open.ts)_
+_See code: [dist/commands/dbms/open.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/open.ts)_
 
 ## `relate dbms:remove-tag DBMS TAGNAME`
 
@@ -210,7 +210,7 @@ EXAMPLE
   $ relate dbms:remove-tag dbmsId "waiting for approval"
 ```
 
-_See code: [dist/commands/dbms/remove-tag.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/remove-tag.ts)_
+_See code: [dist/commands/dbms/remove-tag.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/remove-tag.ts)_
 
 ## `relate dbms:start [DBMSS]`
 
@@ -233,7 +233,7 @@ EXAMPLES
   $ relate dbms:start -e environment-name
 ```
 
-_See code: [dist/commands/dbms/start.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/start.ts)_
+_See code: [dist/commands/dbms/start.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/start.ts)_
 
 ## `relate dbms:stop [DBMSS]`
 
@@ -256,7 +256,7 @@ EXAMPLES
   $ relate dbms:stop -e environment-name
 ```
 
-_See code: [dist/commands/dbms/stop.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/stop.ts)_
+_See code: [dist/commands/dbms/stop.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/stop.ts)_
 
 ## `relate dbms:uninstall DBMS`
 
@@ -279,7 +279,7 @@ EXAMPLES
   $ relate dbms:uninstall my-dbms -u dbms-user
 ```
 
-_See code: [dist/commands/dbms/uninstall.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/uninstall.ts)_
+_See code: [dist/commands/dbms/uninstall.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/uninstall.ts)_
 
 ## `relate dbms:upgrade DBMS`
 
@@ -304,4 +304,4 @@ EXAMPLES
   relate dbms:upgrade <dbms-id> -v 4.0.5
 ```
 
-_See code: [dist/commands/dbms/upgrade.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/dbms/upgrade.ts)_
+_See code: [dist/commands/dbms/upgrade.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/dbms/upgrade.ts)_

--- a/packages/cli/docs/environment.md
+++ b/packages/cli/docs/environment.md
@@ -35,7 +35,7 @@ EXAMPLES
   $ relate env:api-token my-app -h localhost:3000
 ```
 
-_See code: [dist/commands/environment/api-token.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/environment/api-token.ts)_
+_See code: [dist/commands/environment/api-token.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/environment/api-token.ts)_
 
 ## `relate environment:init`
 
@@ -59,7 +59,7 @@ EXAMPLES
   $ relate env:init --name=remote-environment-name --type=REMOTE --httpOrigin=https://url.of.hosted.relate.com
 ```
 
-_See code: [dist/commands/environment/init.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/environment/init.ts)_
+_See code: [dist/commands/environment/init.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/environment/init.ts)_
 
 ## `relate environment:list`
 
@@ -76,7 +76,7 @@ EXAMPLE
   $ relate env:list
 ```
 
-_See code: [dist/commands/environment/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/environment/list.ts)_
+_See code: [dist/commands/environment/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/environment/list.ts)_
 
 ## `relate environment:login [ENVIRONMENT]`
 
@@ -97,7 +97,7 @@ EXAMPLES
   $ relate env:login environment-supporting-login
 ```
 
-_See code: [dist/commands/environment/login.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/environment/login.ts)_
+_See code: [dist/commands/environment/login.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/environment/login.ts)_
 
 ## `relate environment:open [ENVIRONMENT]`
 
@@ -122,7 +122,7 @@ EXAMPLES
   $ relate env:open environment-name -L
 ```
 
-_See code: [dist/commands/environment/open.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/environment/open.ts)_
+_See code: [dist/commands/environment/open.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/environment/open.ts)_
 
 ## `relate environment:use ENVIRONMENT`
 
@@ -142,4 +142,4 @@ EXAMPLE
   $ relate env:use environment-to-set-as-active
 ```
 
-_See code: [dist/commands/environment/use.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/environment/use.ts)_
+_See code: [dist/commands/environment/use.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/environment/use.ts)_

--- a/packages/cli/docs/extension.md
+++ b/packages/cli/docs/extension.md
@@ -30,7 +30,7 @@ EXAMPLES
   $ relate ext:install extension-name -V 1.0.0
 ```
 
-_See code: [dist/commands/extension/install.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/extension/install.ts)_
+_See code: [dist/commands/extension/install.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/extension/install.ts)_
 
 ## `relate extension:link [FILEPATH]`
 
@@ -50,7 +50,7 @@ EXAMPLE
   $ relate ext:link file/path/to/extension
 ```
 
-_See code: [dist/commands/extension/link.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/extension/link.ts)_
+_See code: [dist/commands/extension/link.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/extension/link.ts)_
 
 ## `relate extension:list`
 
@@ -71,7 +71,7 @@ EXAMPLES
   $ relate ext:list -e environment-name
 ```
 
-_See code: [dist/commands/extension/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/extension/list.ts)_
+_See code: [dist/commands/extension/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/extension/list.ts)_
 
 ## `relate extension:uninstall [EXTENSION]`
 
@@ -96,4 +96,4 @@ EXAMPLES
   $ relate ext:uninstall extension-name
 ```
 
-_See code: [dist/commands/extension/uninstall.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/extension/uninstall.ts)_
+_See code: [dist/commands/extension/uninstall.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/extension/uninstall.ts)_

--- a/packages/cli/docs/project.md
+++ b/packages/cli/docs/project.md
@@ -38,7 +38,7 @@ EXAMPLES
   $ relate project:add-dbms -p my-project -n dbms-name-in-project -u dbms-user-to-create-token-for
 ```
 
-_See code: [dist/commands/project/add-dbms.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/add-dbms.ts)_
+_See code: [dist/commands/project/add-dbms.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/add-dbms.ts)_
 
 ## `relate project:add-file SOURCE`
 
@@ -62,7 +62,7 @@ EXAMPLES
   $ relate project:add-file -p my-project -d /path/to/name.file
 ```
 
-_See code: [dist/commands/project/add-file.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/add-file.ts)_
+_See code: [dist/commands/project/add-file.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/add-file.ts)_
 
 ## `relate project:init TARGETDIR`
 
@@ -82,7 +82,7 @@ EXAMPLES
   $ relate project:init /path/to/target/project/dir --name=my-project
 ```
 
-_See code: [dist/commands/project/init.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/init.ts)_
+_See code: [dist/commands/project/init.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/init.ts)_
 
 ## `relate project:link FILEPATH`
 
@@ -96,7 +96,7 @@ EXAMPLE
   $ relate project:link /path/to/target/project/dir
 ```
 
-_See code: [dist/commands/project/link.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/link.ts)_
+_See code: [dist/commands/project/link.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/link.ts)_
 
 ## `relate project:list`
 
@@ -114,7 +114,7 @@ EXAMPLES
   $ relate project:list -e environment-name
 ```
 
-_See code: [dist/commands/project/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/list.ts)_
+_See code: [dist/commands/project/list.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/list.ts)_
 
 ## `relate project:list-dbmss`
 
@@ -134,7 +134,7 @@ EXAMPLES
   $ relate project:list-dbmss -p my-project
 ```
 
-_See code: [dist/commands/project/list-dbmss.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/list-dbmss.ts)_
+_See code: [dist/commands/project/list-dbmss.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/list-dbmss.ts)_
 
 ## `relate project:list-files`
 
@@ -154,7 +154,7 @@ EXAMPLES
   $ relate project:list-files -p my-project
 ```
 
-_See code: [dist/commands/project/list-files.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/list-files.ts)_
+_See code: [dist/commands/project/list-files.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/list-files.ts)_
 
 ## `relate project:open`
 
@@ -176,7 +176,7 @@ EXAMPLES
   $ relate project:open -p my-project -L
 ```
 
-_See code: [dist/commands/project/open.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/open.ts)_
+_See code: [dist/commands/project/open.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/open.ts)_
 
 ## `relate project:remove-dbms DBMS`
 
@@ -200,7 +200,7 @@ EXAMPLES
   $ relate project:remove-dbms project-dbms-name -p my-project
 ```
 
-_See code: [dist/commands/project/remove-dbms.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/remove-dbms.ts)_
+_See code: [dist/commands/project/remove-dbms.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/remove-dbms.ts)_
 
 ## `relate project:remove-file FILE`
 
@@ -221,4 +221,4 @@ EXAMPLES
   $ relate project:remove-file /project/path/to/name.file -p my-project
 ```
 
-_See code: [dist/commands/project/remove-file.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/dist/commands/project/remove-file.ts)_
+_See code: [dist/commands/project/remove-file.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/remove-file.ts)_

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,7 @@
         "oclif"
     ],
     "oclif": {
+        "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/cli/<% print(commandPath.replace('dist', 'src')) %>",
         "commands": "./dist/commands",
         "helpClass": "./dist/help",
         "description": "Create, manage and use Neo4j graphs from the command line.\nNeo4j Relate is a set of project-oriented tools and services for working with the Neo4j graph platform.",

--- a/packages/cli/src/commands/dbms/info.ts
+++ b/packages/cli/src/commands/dbms/info.ts
@@ -1,4 +1,5 @@
 import {cli} from 'cli-ux';
+import {flags} from '@oclif/command';
 
 import BaseCommand from '../../base.command';
 import {ARGS, FLAGS} from '../../constants';
@@ -26,6 +27,9 @@ export default class InfoCommand extends BaseCommand {
 
     static flags = {
         ...FLAGS.ENVIRONMENT,
+        onlineCheck: flags.boolean({
+            description: 'Check if the DBMS is online',
+        }),
         ...cli.table.flags({except: ['csv']}),
     };
 }

--- a/packages/cli/src/commands/dbms/install.ts
+++ b/packages/cli/src/commands/dbms/install.ts
@@ -28,7 +28,7 @@ export default class InstallCommand extends BaseCommand {
             description: 'Name to give the newly installed DBMS',
             required: REQUIRED_FOR_SCRIPTS,
         }),
-        'no-caching': flags.boolean({
+        noCaching: flags.boolean({
             default: false,
             description: 'Prevent caching of the downloaded DBMS',
         }),

--- a/packages/cli/src/commands/dbms/upgrade.ts
+++ b/packages/cli/src/commands/dbms/upgrade.ts
@@ -22,11 +22,11 @@ export default class UpgradeCommand extends BaseCommand {
     static flags = {
         ...FLAGS.ENVIRONMENT,
         ...FLAGS.VERSION,
-        'no-caching': flags.boolean({
+        noCaching: flags.boolean({
             default: false,
             description: 'Prevent caching of the downloaded DBMS',
         }),
-        'no-migration': flags.boolean({
+        noMigration: flags.boolean({
             default: false,
             description: 'Prevent migrating the data to new formats',
         }),

--- a/packages/cli/src/commands/environment/use.ts
+++ b/packages/cli/src/commands/environment/use.ts
@@ -1,4 +1,5 @@
 import BaseCommand from '../../base.command';
+import {REQUIRED_FOR_SCRIPTS} from '../../constants';
 import {UseModule} from '../../modules/environment/use.module';
 
 export default class UseCommand extends BaseCommand {
@@ -16,7 +17,7 @@ export default class UseCommand extends BaseCommand {
         {
             name: 'environment',
             description: 'Name of the environment to set as active',
-            required: true,
+            required: REQUIRED_FOR_SCRIPTS,
         },
     ];
 }

--- a/packages/cli/src/modules/dbms/info.module.ts
+++ b/packages/cli/src/modules/dbms/info.module.ts
@@ -18,14 +18,16 @@ export class InfoModule implements OnApplicationBootstrap {
 
     async onApplicationBootstrap(): Promise<void> {
         const {flags} = this.parsed;
-        const environment = await this.systemProvider.getEnvironment(flags.environment);
+        const {environment: environmentId, onlineCheck} = flags;
+
+        const environment = await this.systemProvider.getEnvironment(environmentId);
         const namesOrIds = this.parsed.argv;
         const dbmss: Omit<IDbms, 'config'>[] = !namesOrIds.length
             ? (await environment.dbmss.list()).toArray()
             : await Promise.all(namesOrIds.map((n) => environment.dbmss.get(n)));
         const dbmsIds = dbmss.map((dbms) => dbms.id);
 
-        await environment.dbmss.info(dbmsIds, true).then((res) => {
+        await environment.dbmss.info(dbmsIds, onlineCheck).then((res) => {
             const table = res
                 .mapEach((dbms) => {
                     return {

--- a/packages/cli/src/modules/dbms/install.module.ts
+++ b/packages/cli/src/modules/dbms/install.module.ts
@@ -38,13 +38,11 @@ export class InstallModule implements OnApplicationBootstrap {
 
     async onApplicationBootstrap(): Promise<void> {
         const {args, flags} = this.parsed;
-        const {environment: environmentId, limited} = flags;
+        const {environment: environmentId, limited, noCaching} = flags;
         const environment = await this.systemProvider.getEnvironment(environmentId);
         this.registerHookListeners();
 
         const name = flags.name || (await inputPrompt('Enter the DBMS name'));
-
-        const noCaching = flags['no-caching'];
 
         let {version = ''} = args;
         let edition: NEO4J_EDITION | undefined;

--- a/packages/cli/src/modules/dbms/upgrade.module.ts
+++ b/packages/cli/src/modules/dbms/upgrade.module.ts
@@ -44,10 +44,8 @@ export class UpgradeModule implements OnApplicationBootstrap {
 
     async onApplicationBootstrap(): Promise<void> {
         const {args, flags} = this.parsed;
-        const {environment: environmentId} = flags;
+        const {environment: environmentId, noCaching, noMigration} = flags;
         let {version = ''} = flags;
-        const noCaching = flags['no-caching'];
-        const noMigration = flags['no-migration'];
         const environment = await this.systemProvider.getEnvironment(environmentId);
         let {dbms: dbmsId = ''} = args;
 

--- a/packages/web/src/entities/dbms/dbms.resolver.ts
+++ b/packages/web/src/entities/dbms/dbms.resolver.ts
@@ -63,9 +63,9 @@ export class DBMSResolver {
     @Query(() => [DbmsInfo])
     async [PUBLIC_GRAPHQL_METHODS.INFO_DBMSS](
         @Context('environment') environment: Environment,
-        @Args() {dbmsIds}: DbmssArgs,
+        @Args() {dbmsIds, onlineCheck}: DbmssArgs,
     ): Promise<List<IDbmsInfo>> {
-        return environment.dbmss.info(dbmsIds);
+        return environment.dbmss.info(dbmsIds, onlineCheck);
     }
 
     @Mutation(() => [String])

--- a/packages/web/src/entities/dbms/dbms.types.ts
+++ b/packages/web/src/entities/dbms/dbms.types.ts
@@ -27,6 +27,9 @@ export class DbmsInfo extends Dbms {
     @Field(() => String)
     status: string;
 
+    @Field(() => String)
+    serverStatus: string;
+
     @Field(() => String, {nullable: true})
     version?: string;
 
@@ -44,6 +47,9 @@ export class DbmsArgs extends EnvironmentArgs {
 export class DbmssArgs extends EnvironmentArgs {
     @Field(() => [String])
     dbmsIds: string[];
+
+    @Field(() => Boolean, {nullable: true})
+    onlineCheck?: boolean;
 }
 
 @ArgsType()


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Consistency and performance improvements.


### What is the current behavior?
- `infoDbmss` doesn't return the server status of DBMSs.
- Some CLI flags are camel case and some are kebab case.
- When passing the names or IDs of DBMSs to `dbms:info`, the status of each DBMS is retrieved twice.
- Links to the source code on the CLI are broken.

### What is the new behavior?
- `infoDbmss` now accepts an optional `onlineCheck` argument, and returns the server status of DBMSs.
- All CLI flags are now camel case.
- `dbms:info` always retrieves the info of DBMSs once.
- Links to the source code on the CLI are pointing to the right location.

### Does this PR introduce a breaking change?
Yes. All kebab case CLI flags have been converted to camel case. And `dbms:info` is not performing the online check by default.


### Other information:
