### PR TITLE
add force flag for overwriting project files

### DIFF
--- a/packages/cli/docs/project.md
+++ b/packages/cli/docs/project.md
@@ -52,6 +52,7 @@ OPTIONS
   -d, --destination=destination  The relative path of the file (including name) in the project
   -e, --environment=environment  Name of the environment to run the command against
   -p, --project=project          (required) Name of the project to run the command against
+  --overwrite                    Overwrite existing destination file
 
 DESCRIPTION
   Useful for remote environments.
@@ -59,7 +60,8 @@ DESCRIPTION
 EXAMPLES
   $ relate project:add-file
   $ relate project:add-file -e environment-name
-  $ relate project:add-file -p my-project -d /path/to/name.file
+  $ relate project:add-file -p my-project -d relative/path/to/destination.file /path/to/source.file
+  $ relate project:add-file -p my-project -d /path/to/existing-destination.file /path/to/source.file --overwrite
 ```
 
 _See code: [dist/commands/project/add-file.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/add-file.ts)_

--- a/packages/cli/src/commands/project/add-file.ts
+++ b/packages/cli/src/commands/project/add-file.ts
@@ -15,7 +15,8 @@ export default class AddFileCommand extends BaseCommand {
     static examples = [
         '$ relate project:add-file',
         '$ relate project:add-file -e environment-name',
-        '$ relate project:add-file -p my-project -d /path/to/name.file',
+        '$ relate project:add-file -p my-project -d relative/path/to/dest.file /path/to/source.file',
+        '$ relate project:add-file -p my-project -d /path/to/existing-dest.file /path/to/source.file --overwrite',
     ];
 
     static args = [
@@ -31,6 +32,10 @@ export default class AddFileCommand extends BaseCommand {
         destination: flags.string({
             char: 'd',
             description: 'The relative path of the file (including name) in the project',
+        }),
+        overwrite: flags.boolean({
+            default: false,
+            description: 'Overwrite existing destination file',
         }),
     };
 }

--- a/packages/cli/src/modules/project/add-file.module.ts
+++ b/packages/cli/src/modules/project/add-file.module.ts
@@ -21,7 +21,7 @@ export class AddFileModule implements OnApplicationBootstrap {
     async onApplicationBootstrap(): Promise<void> {
         const {args, flags} = this.parsed;
         let {source} = args;
-        const {environment: environmentId, destination} = flags;
+        const {environment: environmentId, destination, overwrite} = flags;
         const environment = await this.systemProvider.getEnvironment(environmentId);
         const projectId = flags.project || (await selectProjectPrompt('Select a Project', environment));
 
@@ -33,7 +33,7 @@ export class AddFileModule implements OnApplicationBootstrap {
             }
         }
 
-        return environment.projects.addFile(projectId, path.resolve(source), destination).then((added) => {
+        return environment.projects.addFile(projectId, path.resolve(source), destination, overwrite).then((added) => {
             this.utils.log(`Added "${added.name}" to "${added.directory}" in project`);
         });
     }

--- a/packages/cli/src/modules/project/project.e2e.ts
+++ b/packages/cli/src/modules/project/project.e2e.ts
@@ -97,6 +97,19 @@ describe('$relate project', () => {
         ).rejects.toEqual(new InvalidArgumentError(`File ${TEST_FILE_NAME} already exists at that destination`));
     });
 
+    test.stdout().it('does overwrite file with overwite flag', async (ctx) => {
+        await AddFileCommand.run([
+            TEST_PROJECT_FILE,
+            '--environment',
+            TEST_ENVIRONMENT_ID,
+            '--project',
+            TEST_PROJECT_NAME,
+            '--overwrite',
+        ]);
+        expect(ctx.stdout).toContain(TEST_FILE_NAME);
+        expect(ctx.stdout).not.toContain(TEST_FILE_OTHER_NAME);
+    });
+
     test.stdout().it('adds file with destination', async (ctx) => {
         await AddFileCommand.run([
             TEST_PROJECT_FILE,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Currently common and web packages allow for an overwrite param for project add file methods. This work gets the CLI up to date with these changes.

### What is the current behavior?
Cannot overwrite an existing project file with CLI package


### What is the new behavior?
Can now overwrite an existing file


### Does this PR introduce a breaking change?
no


### Other information:
