### PR TITLE
add is-symlink check and update project and dbms link logic

### DIFF
--- a/packages/common/src/utils/files/index.ts
+++ b/packages/common/src/utils/files/index.ts
@@ -1,3 +1,4 @@
 export {PropertyEntries, readPropertiesFile} from './read-properties-file';
 export {writePropertiesFile} from './write-properties-file';
 export * from './map-file-to-model';
+export * from './is-symlink';

--- a/packages/common/src/utils/files/is-symlink.ts
+++ b/packages/common/src/utils/files/is-symlink.ts
@@ -1,0 +1,10 @@
+import fse from 'fs-extra';
+
+export async function isSymlink(filePath: string): Promise<boolean> {
+    try {
+        const stat = await fse.lstat(filePath);
+        return stat.isSymbolicLink();
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
- add `is-symlink` util
- update `dbms.local` and `project.local` `link` methods to `unlink` if already a symlink. This is to allow relinking broken symlinks.
- updated `project` link to be in line with `dbms` link


### What is the current behavior?
If a dbms or project is already linked, and the target is moved, the symlink will remain and is broken. Project link also doesnt handle linking a previously linked Project (already has a manifest) in the same way as dbms

### What is the new behavior?
- When linking for project or dbms, when it already has a manifest and so previously linked, the presence of a symlink is checked and unlinked first. 
- Project link in line with dbms link now.

### Does this PR introduce a breaking change?
No, other than a discussion around a flag to prevent removing 'broken' links in the case when projects, for example, are loaded via storage device and not always available. This is best handled when that work is done in future to keep the scope focus here.

### Other information:
