### PR TITLE
ensure global Relate data path exists before write file

### DIFF
--- a/packages/common/src/system/verifyAcceptedTerms.ts
+++ b/packages/common/src/system/verifyAcceptedTerms.ts
@@ -19,6 +19,10 @@ export const acceptTerms = async (app: string): Promise<void> => {
         return;
     }
 
+    if (!(await fse.pathExists(envPaths().data))) {
+        await fse.ensureDir(envPaths().data);
+    }
+
     await fse.writeFile(ACCEPTED_TERMS_PATH, `${LICENSE_NAME} (${app})`);
 };
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
- ensure `envPaths().data` exists before attempting to write the accepted terms
- added to `acceptTerms` as we use this in Desktop. Left `verifyAcceptedTerms` alone as where we call it in `system.provider`, we ensure dirs before


### What is the current behavior?
- attempt to write the accepted terms to the data path before ensuring it is there


### What is the new behavior?
- ensure data path before attempting to write


### Does this PR introduce a breaking change?
none


### Other information:
