### PR TITLE
Refactor dbmss.link and projects.link

### DIFF
--- a/packages/cli/docs/project.md
+++ b/packages/cli/docs/project.md
@@ -5,7 +5,7 @@ Projects bring files and data together.
 
 * [`relate project:add-dbms DBMS`](#relate-projectadd-dbms-dbms)
 * [`relate project:add-file SOURCE`](#relate-projectadd-file-source)
-* [`relate project:init TARGETDIR`](#relate-projectinit-targetdir)
+* [`relate project:init`](#relate-projectinit)
 * [`relate project:link FILEPATH`](#relate-projectlink-filepath)
 * [`relate project:list`](#relate-projectlist)
 * [`relate project:list-dbmss`](#relate-projectlist-dbmss)
@@ -66,13 +66,13 @@ EXAMPLES
 
 _See code: [dist/commands/project/add-file.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.15/packages/cli/src/commands/project/add-file.ts)_
 
-## `relate project:init TARGETDIR`
+## `relate project:init`
 
 Initialize a new project
 
 ```
 USAGE
-  $ relate project:init TARGETDIR
+  $ relate project:init
 
 OPTIONS
   -e, --environment=environment  Name of the environment to run the command against
@@ -93,6 +93,9 @@ Link a project
 ```
 USAGE
   $ relate project:link FILEPATH
+
+OPTIONS
+  -n, --name=name  (required) Name of the project
 
 EXAMPLE
   $ relate project:link /path/to/target/project/dir

--- a/packages/cli/src/commands/project/init.ts
+++ b/packages/cli/src/commands/project/init.ts
@@ -17,14 +17,6 @@ export default class InitCommand extends BaseCommand {
         '$ relate project:init /path/to/target/project/dir --name=my-project',
     ];
 
-    static args = [
-        {
-            name: 'targetDir',
-            // @todo: this is optional is projects.abstract
-            required: true,
-        },
-    ];
-
     static flags = {
         ...FLAGS.ENVIRONMENT,
         name: flags.string({

--- a/packages/cli/src/commands/project/link.ts
+++ b/packages/cli/src/commands/project/link.ts
@@ -1,4 +1,6 @@
+import {flags} from '@oclif/command';
 import BaseCommand from '../../base.command';
+import {REQUIRED_FOR_SCRIPTS} from '../../constants';
 import {LinkModule} from '../../modules/project/link.module';
 
 export default class LinkCommand extends BaseCommand {
@@ -16,4 +18,12 @@ export default class LinkCommand extends BaseCommand {
             required: true,
         },
     ];
+
+    static flags = {
+        name: flags.string({
+            char: 'n',
+            description: 'Name of the project',
+            required: REQUIRED_FOR_SCRIPTS,
+        }),
+    };
 }

--- a/packages/cli/src/modules/dbms/link.module.ts
+++ b/packages/cli/src/modules/dbms/link.module.ts
@@ -40,7 +40,7 @@ export class LinkModule implements OnApplicationBootstrap {
         const {dbmss} = await this.systemProvider.getEnvironment();
         const resolvedPath = path.resolve(filePath);
 
-        await dbmss.link(name, resolvedPath).then((res) => {
+        await dbmss.link(resolvedPath, name).then((res) => {
             this.utils.log(res.name);
         });
     }

--- a/packages/cli/src/modules/project/init.module.ts
+++ b/packages/cli/src/modules/project/init.module.ts
@@ -1,7 +1,6 @@
 import {OnApplicationBootstrap, Module, Inject} from '@nestjs/common';
 import cli from 'cli-ux';
 import {IProjectInput, SystemModule, SystemProvider} from '@relate/common';
-import path from 'path';
 
 import InitCommand from '../../commands/project/init';
 import {inputPrompt} from '../../prompts';
@@ -19,12 +18,10 @@ export class InitModule implements OnApplicationBootstrap {
     ) {}
 
     async onApplicationBootstrap(): Promise<void> {
-        const {args, flags} = this.parsed;
+        const {flags} = this.parsed;
         let {name} = flags;
         const {environment} = flags;
-        const {targetDir} = args;
         const {projects} = await this.systemProvider.getEnvironment(environment);
-        const resolvedDir = path.resolve(targetDir);
 
         name = name || (await inputPrompt('Enter project name'));
 
@@ -35,7 +32,7 @@ export class InitModule implements OnApplicationBootstrap {
 
         cli.action.start('Creating project');
 
-        return projects.create(config, resolvedDir).then((created) => {
+        return projects.create(config).then((created) => {
             cli.action.stop();
             this.utils.log(created.name);
         });

--- a/packages/cli/src/modules/project/link.module.ts
+++ b/packages/cli/src/modules/project/link.module.ts
@@ -3,6 +3,7 @@ import {SystemModule, SystemProvider} from '@relate/common';
 import path from 'path';
 
 import LinkCommand from '../../commands/project/link';
+import {inputPrompt} from '../../prompts';
 
 @Module({
     exports: [],
@@ -17,12 +18,14 @@ export class LinkModule implements OnApplicationBootstrap {
     ) {}
 
     async onApplicationBootstrap(): Promise<void> {
-        const {args} = this.parsed;
+        const {args, flags} = this.parsed;
         const {filePath} = args;
         const {projects} = await this.systemProvider.getEnvironment();
-        const resolvedPath = path.resolve(filePath);
 
-        return projects.link(resolvedPath).then((res) => {
+        const resolvedPath = path.resolve(filePath);
+        const name = flags.name || (await inputPrompt('Enter the project name'));
+
+        return projects.link(resolvedPath, name).then((res) => {
             this.utils.log(res.name);
         });
     }

--- a/packages/cli/src/modules/project/project.e2e.ts
+++ b/packages/cli/src/modules/project/project.e2e.ts
@@ -15,7 +15,6 @@ import RemoveDbmsCommand from '../../commands/project/remove-dbms';
 
 const TEST_PROJECT_NAME = 'Cli Project';
 const TEST_FILE_NAME = 'cliProject.tmp';
-const TEST_PROJECT_DIR = path.join(envPaths().tmp, TEST_PROJECT_NAME);
 const TEST_PROJECT_FILE = path.join(envPaths().tmp, TEST_FILE_NAME);
 const TEST_FILE_OTHER_NAME = 'cliProject.pem';
 const TEST_FILE_DESTINATION_DIR = path.normalize('foo/bar');
@@ -40,7 +39,6 @@ describe('$relate project', () => {
         TEST_DB_NAME = name;
         TEST_ENVIRONMENT_ID = dbmss.environment.id;
 
-        await fse.ensureDir(TEST_PROJECT_DIR);
         await fse.ensureFile(TEST_PROJECT_FILE);
         await StartCommand.run([TEST_DB_NAME, '--environment', TEST_ENVIRONMENT_ID]);
     });
@@ -48,7 +46,6 @@ describe('$relate project', () => {
     afterAll(async () => {
         await dbmss.teardown();
         await fse.remove(path.join(envPaths().data, PROJECTS_DIR_NAME, TEST_PROJECT_NAME));
-        await fse.remove(TEST_PROJECT_DIR);
         await fse.remove(TEST_PROJECT_FILE);
     });
 
@@ -58,7 +55,7 @@ describe('$relate project', () => {
     });
 
     test.stdout().it('inits a new project', async (ctx) => {
-        await InitCommand.run([TEST_PROJECT_DIR, '--environment', TEST_ENVIRONMENT_ID, '--name', TEST_PROJECT_NAME]);
+        await InitCommand.run(['--environment', TEST_ENVIRONMENT_ID, '--name', TEST_PROJECT_NAME]);
         expect(ctx.stdout).toContain(TEST_PROJECT_NAME);
     });
 

--- a/packages/common/documentation/classes/dbmssabstract.md
+++ b/packages/common/documentation/classes/dbmssabstract.md
@@ -162,7 +162,7 @@ ___
 
 ### `Abstract` link
 
-▸ **link**(`name`: string, `rootPath`: string): *Promise‹IDbmsInfo›*
+▸ **link**(`externalPath`: string, `name`: string): *Promise‹IDbmsInfo›*
 
 *Defined in [dbmss/dbmss.abstract.ts:83](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/dbmss/dbmss.abstract.ts#L83)*
 
@@ -172,8 +172,8 @@ Links an existing DBMS to relate
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`name` | string | Name of DBMS |
-`rootPath` | string | Path to DBMS root  |
+`externalPath` | string | Path to DBMS root |
+`name` | string | Name of DBMS  |
 
 **Returns:** *Promise‹IDbmsInfo›*
 

--- a/packages/common/documentation/classes/projectsabstract.md
+++ b/packages/common/documentation/classes/projectsabstract.md
@@ -28,6 +28,7 @@
 * [listFiles](projectsabstract.md#abstract-listfiles)
 * [removeDbms](projectsabstract.md#abstract-removedbms)
 * [removeFile](projectsabstract.md#abstract-removefile)
+* [unlink](projectsabstract.md#abstract-unlink)
 * [writeFile](projectsabstract.md#abstract-writefile)
 
 ## Properties
@@ -42,9 +43,9 @@
 
 ### `Abstract` addDbms
 
-▸ **addDbms**(`projectId`: string, `dbmsName`: string, `dbmsId`: string, `principal?`: undefined | string, `accessToken?`: undefined | string): *Promise‹IProjectDbms›*
+▸ **addDbms**(`nameOrId`: string, `dbmsName`: string, `dbmsId`: string, `principal?`: undefined | string, `accessToken?`: undefined | string): *Promise‹IProjectDbms›*
 
-*Defined in [projects/projects.abstract.ts:102](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L102)*
+*Defined in [projects/projects.abstract.ts:103](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L103)*
 
 Adds DBMS to given project
 
@@ -52,7 +53,7 @@ Adds DBMS to given project
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`projectId` | string | - |
+`nameOrId` | string | Project name or ID |
 `dbmsName` | string | Name to give DBMS in project |
 `dbmsId` | string | - |
 `principal?` | undefined &#124; string | DBMS principal |
@@ -64,9 +65,9 @@ ___
 
 ### `Abstract` addFile
 
-▸ **addFile**(`projectId`: string, `source`: string, `destination?`: undefined | string, `overwrite?`: undefined | false | true): *Promise‹IRelateFile›*
+▸ **addFile**(`nameOrId`: string, `source`: string, `destination?`: undefined | string, `overwrite?`: undefined | false | true): *Promise‹IRelateFile›*
 
-*Defined in [projects/projects.abstract.ts:59](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L59)*
+*Defined in [projects/projects.abstract.ts:65](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L65)*
 
 Adds file (copy) to project
 
@@ -74,7 +75,7 @@ Adds file (copy) to project
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`projectId` | string | - |
+`nameOrId` | string | - |
 `source` | string | - |
 `destination?` | undefined &#124; string |   |
 `overwrite?` | undefined &#124; false &#124; true | - |
@@ -85,9 +86,9 @@ ___
 
 ### `Abstract` create
 
-▸ **create**(`manifest`: Omit‹IProjectInput, "id"›, `path?`: undefined | string): *Promise‹IProject›*
+▸ **create**(`manifest`: Omit‹IProjectInput, "id"›): *Promise‹IProject›*
 
-*Defined in [projects/projects.abstract.ts:26](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L26)*
+*Defined in [projects/projects.abstract.ts:25](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L25)*
 
 Creates new project
 
@@ -95,8 +96,7 @@ Creates new project
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`manifest` | Omit‹IProjectInput, "id"› | Project data |
-`path?` | undefined &#124; string | Path to project root  |
+`manifest` | Omit‹IProjectInput, "id"› | Project data  |
 
 **Returns:** *Promise‹IProject›*
 
@@ -104,9 +104,9 @@ ___
 
 ### `Abstract` get
 
-▸ **get**(`nameOrID`: string): *Promise‹IProject›*
+▸ **get**(`nameOrId`: string): *Promise‹IProject›*
 
-*Defined in [projects/projects.abstract.ts:32](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L32)*
+*Defined in [projects/projects.abstract.ts:31](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L31)*
 
 Gets a project by name
 
@@ -114,7 +114,7 @@ Gets a project by name
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`nameOrID` | string |   |
+`nameOrId` | string |   |
 
 **Returns:** *Promise‹IProject›*
 
@@ -122,7 +122,7 @@ ___
 
 ### `Abstract` link
 
-▸ **link**(`filePath`: string): *Promise‹IProject›*
+▸ **link**(`externalPath`: string, `name`: string): *Promise‹IProject›*
 
 *Defined in [projects/projects.abstract.ts:44](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L44)*
 
@@ -132,7 +132,8 @@ Links an existing project
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`filePath` | string | Path to project root  |
+`externalPath` | string | Path to project root |
+`name` | string |   |
 
 **Returns:** *Promise‹IProject›*
 
@@ -142,7 +143,7 @@ ___
 
 ▸ **list**(`filters?`: List‹IRelateFilter› | IRelateFilter[]): *Promise‹List‹IProject››*
 
-*Defined in [projects/projects.abstract.ts:38](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L38)*
+*Defined in [projects/projects.abstract.ts:37](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L37)*
 
 List all available projects
 
@@ -158,9 +159,9 @@ ___
 
 ### `Abstract` listDbmss
 
-▸ **listDbmss**(`projectId`: string, `filters?`: List‹IRelateFilter› | IRelateFilter[]): *Promise‹List‹IProjectDbms››*
+▸ **listDbmss**(`nameOrId`: string, `filters?`: List‹IRelateFilter› | IRelateFilter[]): *Promise‹List‹IProjectDbms››*
 
-*Defined in [projects/projects.abstract.ts:92](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L92)*
+*Defined in [projects/projects.abstract.ts:93](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L93)*
 
 Lists DBMSs for given project
 
@@ -168,7 +169,7 @@ Lists DBMSs for given project
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`projectId` | string | - |
+`nameOrId` | string | - |
 `filters?` | List‹IRelateFilter› &#124; IRelateFilter[] | Filters to apply  |
 
 **Returns:** *Promise‹List‹IProjectDbms››*
@@ -177,9 +178,9 @@ ___
 
 ### `Abstract` listFiles
 
-▸ **listFiles**(`projectId`: string, `filters?`: List‹IRelateFilter› | IRelateFilter[]): *Promise‹List‹IRelateFile››*
+▸ **listFiles**(`nameOrId`: string, `filters?`: List‹IRelateFilter› | IRelateFilter[]): *Promise‹List‹IRelateFile››*
 
-*Defined in [projects/projects.abstract.ts:51](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L51)*
+*Defined in [projects/projects.abstract.ts:57](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L57)*
 
 List files for given project
 
@@ -187,7 +188,7 @@ List files for given project
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`projectId` | string | - |
+`nameOrId` | string | - |
 `filters?` | List‹IRelateFilter› &#124; IRelateFilter[] | Filters to apply  |
 
 **Returns:** *Promise‹List‹IRelateFile››*
@@ -196,9 +197,9 @@ ___
 
 ### `Abstract` removeDbms
 
-▸ **removeDbms**(`projectId`: string, `dbmsName`: string): *Promise‹IProjectDbms›*
+▸ **removeDbms**(`nameOrId`: string, `dbmsName`: string): *Promise‹IProjectDbms›*
 
-*Defined in [projects/projects.abstract.ts:115](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L115)*
+*Defined in [projects/projects.abstract.ts:116](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L116)*
 
 removes DBMS from given project
 
@@ -206,7 +207,7 @@ removes DBMS from given project
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`projectId` | string | - |
+`nameOrId` | string | Project name or ID |
 `dbmsName` | string |   |
 
 **Returns:** *Promise‹IProjectDbms›*
@@ -215,9 +216,9 @@ ___
 
 ### `Abstract` removeFile
 
-▸ **removeFile**(`projectId`: string, `relativePath`: string): *Promise‹IRelateFile›*
+▸ **removeFile**(`nameOrId`: string, `relativePath`: string): *Promise‹IRelateFile›*
 
-*Defined in [projects/projects.abstract.ts:85](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L85)*
+*Defined in [projects/projects.abstract.ts:86](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L86)*
 
 Removes file from given project
 
@@ -225,18 +226,36 @@ Removes file from given project
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`projectId` | string | - |
+`nameOrId` | string | - |
 `relativePath` | string | Path relative to project  |
 
 **Returns:** *Promise‹IRelateFile›*
 
 ___
 
+### `Abstract` unlink
+
+▸ **unlink**(`nameOrId`: string): *Promise‹IProject›*
+
+*Defined in [projects/projects.abstract.ts:50](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L50)*
+
+Unlinks a linked project
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`nameOrId` | string |   |
+
+**Returns:** *Promise‹IProject›*
+
+___
+
 ### `Abstract` writeFile
 
-▸ **writeFile**(`projectId`: string, `destination`: string, `data`: string | Buffer, `writeFlag?`: WriteFileFlag): *Promise‹IRelateFile›*
+▸ **writeFile**(`nameOrId`: string, `destination`: string, `data`: string | Buffer, `writeFlag?`: WriteFileFlag): *Promise‹IRelateFile›*
 
-*Defined in [projects/projects.abstract.ts:73](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L73)*
+*Defined in [projects/projects.abstract.ts:74](https://github.com/neo4j-devtools/relate/blob/master/packages/common/src/entities/projects/projects.abstract.ts#L74)*
 
 Adds file (write) to project
 
@@ -244,7 +263,7 @@ Adds file (write) to project
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`projectId` | string | - |
+`nameOrId` | string | - |
 `destination` | string | - |
 `data` | string &#124; Buffer | - |
 `writeFlag?` | WriteFileFlag |   |

--- a/packages/common/src/entities/backups/backup.local.ts
+++ b/packages/common/src/entities/backups/backup.local.ts
@@ -71,13 +71,13 @@ export class LocalBackups extends BackupAbstract<LocalEnvironment> {
         const result = await extract(backupPath, tmpPath);
 
         await fse.move(result, outputTarget);
-        await fse.writeJSON(path.join(outputTarget, BACKUP_MANIFEST_FILE), manifest);
+        await fse.writeJSON(path.join(outputTarget, BACKUP_MANIFEST_FILE), manifest, {encoding: 'utf8'});
 
         const restoredEntityManifestPath = path.join(outputTarget, getManifestName(manifest.entityType));
-        const restoredEntityManifest = await fse.readJSON(restoredEntityManifestPath);
+        const restoredEntityManifest = await fse.readJSON(restoredEntityManifestPath, {encoding: 'utf-8'});
         const updated = updateRestoredEntityManifest(manifest, restoredEntityId, restoredEntityManifest);
 
-        await fse.writeJSON(restoredEntityManifestPath, updated);
+        await fse.writeJSON(restoredEntityManifestPath, updated, {encoding: 'utf8'});
 
         return {
             entityType: manifest.entityType,
@@ -158,7 +158,7 @@ export class LocalBackups extends BackupAbstract<LocalEnvironment> {
 
     private async readManifestFile(filePath: string): Promise<IRelateBackup> {
         try {
-            const config = await fse.readJson(filePath);
+            const config = await fse.readJSON(filePath, {encoding: 'utf-8'});
 
             return new RelateBackupModel({
                 ...config,
@@ -190,7 +190,7 @@ export class LocalBackups extends BackupAbstract<LocalEnvironment> {
             id: backupId,
         });
 
-        await fse.writeJSON(configFileName, withUpdates);
+        await fse.writeJSON(configFileName, withUpdates, {encoding: 'utf8'});
 
         return this.getBackupManifest(backupId);
     }

--- a/packages/common/src/entities/dbmss/clone.test.ts
+++ b/packages/common/src/entities/dbmss/clone.test.ts
@@ -38,7 +38,7 @@ describe('LocalDbmss - clone', () => {
         await fse.move(originalDbms.rootPath!, linkedDbmsPath);
 
         const linkedName = testDbmss.createName();
-        const linkedDbms = await env.dbmss.link(linkedName, linkedDbmsPath!);
+        const linkedDbms = await env.dbmss.link(linkedDbmsPath!, linkedName);
 
         const clonedName = testDbmss.createName();
         const clonedDbms = await env.dbmss.clone(linkedDbms.id, clonedName);

--- a/packages/common/src/entities/dbmss/dbmss.abstract.ts
+++ b/packages/common/src/entities/dbmss/dbmss.abstract.ts
@@ -77,10 +77,10 @@ export abstract class DbmssAbstract<Env extends EnvironmentAbstract> {
 
     /**
      * Links an existing DBMS to relate
-     * @param   name        Name of DBMS
-     * @param   rootPath    Path to DBMS root
+     * @param   externalPath    Path to DBMS root
+     * @param   name            Name of DBMS
      */
-    abstract link(name: string, rootPath: string): Promise<IDbmsInfo>;
+    abstract link(externalPath: string, name: string): Promise<IDbmsInfo>;
 
     /**
      * Clone a DBMS

--- a/packages/common/src/entities/dbmss/dbmss.local.ts
+++ b/packages/common/src/entities/dbmss/dbmss.local.ts
@@ -308,7 +308,7 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
         // If a manifest exists in the target, path use it
         /* eslint-disable indent */
         const rawManifest = manifestExists
-            ? await fse.readJson(manifestPath)
+            ? await fse.readJSON(manifestPath, {encoding: 'utf-8'})
             : {
                   name,
                   id: uuidv4(),

--- a/packages/common/src/entities/dbmss/dbmss.local.ts
+++ b/packages/common/src/entities/dbmss/dbmss.local.ts
@@ -293,62 +293,61 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
         }
     }
 
-    async link(name: string, rootPath: string): Promise<IDbmsInfo> {
-        const exists = await this.list([
-            {
-                field: 'name',
-                value: name,
-            },
-        ]);
-
-        if (!exists.isEmpty) {
-            throw new InvalidArgumentError(`DBMS "${name}" already exists`, ['Use a unique name']);
-        }
-
-        const alreadyHasManifest = await fse.pathExists(path.join(rootPath, DBMS_MANIFEST_FILE));
-
-        if (alreadyHasManifest) {
-            const {id} = await fse.readJson(path.join(rootPath, DBMS_MANIFEST_FILE));
-            const target = this.environment.getEntityRootPath(ENTITY_TYPES.DBMS, id);
-            const targetExists = await fse.pathExists(target);
-
-            // symlink is correctly pointing to an existing path
-            // no need to do anything
-            if (targetExists) {
-                throw new InvalidArgumentError(`DBMS "${name}" already managed by relate`);
-            }
-
-            // symlink is no longer correctly pointing to an existing path
-            // unlink and link again
-            if (await isSymlink(target)) {
-                await fse.unlink(target);
-            }
-            await fse.symlink(rootPath, target, 'junction');
-
-            return this.get(id);
-        }
-
-        const newId = uuidv4();
-        const info = await getDistributionInfo(rootPath);
-
+    async link(externalPath: string, name: string): Promise<IDbmsInfo> {
+        // Make sure the path we're getting is an actual DBMS
+        const info = await getDistributionInfo(externalPath);
         if (!info || !semver.satisfies(info.version, NEO4J_SUPPORTED_VERSION_RANGE)) {
-            throw new InvalidArgumentError(`Path "${rootPath}" does not seem to be a valid neo4j DBMS`, [
+            throw new InvalidArgumentError(`Path "${externalPath}" does not seem to be a valid neo4j DBMS`, [
                 'Use a valid path',
             ]);
         }
 
-        const target = this.environment.getEntityRootPath(ENTITY_TYPES.DBMS, newId);
+        const manifestPath = path.join(externalPath, DBMS_MANIFEST_FILE);
+        const manifestExists = await fse.pathExists(manifestPath);
 
-        await fse.symlink(rootPath, target, 'junction');
-        await this.manifest.update(newId, {name});
+        // If a manifest exists in the target, path use it
+        /* eslint-disable indent */
+        const rawManifest = manifestExists
+            ? await fse.readJson(manifestPath)
+            : {
+                  name,
+                  id: uuidv4(),
+              };
+        /* eslint-enable indent */
+        const manifestModel = new DbmsManifestModel(rawManifest);
+
+        // Don't override existing data
+        const dbmsExists = await this.environment.entityExists(ENTITY_TYPES.DBMS, manifestModel.id);
+        if (dbmsExists) {
+            throw new InvalidArgumentError(`DBMS "${manifestModel.name}" already managed by relate`);
+        }
+
+        // Replace broken symlinks
+        const dbmsPath = this.environment.getEntityRootPath(ENTITY_TYPES.DBMS, manifestModel.id);
+        if (await isSymlink(dbmsPath)) {
+            await fse.unlink(dbmsPath);
+        }
+
+        // Enforce unique names
+        const dbmsNameExists = await this.list([
+            {
+                field: 'name',
+                value: manifestModel.name,
+            },
+        ]);
+        if (!dbmsNameExists.isEmpty) {
+            throw new InvalidArgumentError(`DBMS "${manifestModel.name}" already exists`, ['Use a unique name']);
+        }
+
+        await fse.symlink(externalPath, dbmsPath, 'junction');
+        await this.manifest.update(manifestModel.id, manifestModel);
 
         if (supportsAccessTokens(info)) {
-            await this.installSecurityPlugin(newId);
+            await this.installSecurityPlugin(manifestModel.id);
         }
 
         await this.discoverDbmss();
-
-        return this.get(newId);
+        return this.get(manifestModel.id);
     }
 
     async clone(id: string, name: string): Promise<IDbmsInfo> {

--- a/packages/common/src/entities/dbmss/dbmss.remote.ts
+++ b/packages/common/src/entities/dbmss/dbmss.remote.ts
@@ -151,7 +151,7 @@ export class RemoteDbmss extends DbmssAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteDbmss.name} does not support upgrading DBMSs`);
     }
 
-    link(_name: string, _rootPath: string): Promise<IDbmsInfo> {
+    link(_externalPath: string, _name: string): Promise<IDbmsInfo> {
         throw new NotSupportedError(`${RemoteDbmss.name} does not support linking DBMSs`);
     }
 

--- a/packages/common/src/entities/dbmss/link.test.ts
+++ b/packages/common/src/entities/dbmss/link.test.ts
@@ -2,7 +2,7 @@ import fse from 'fs-extra';
 import path from 'path';
 
 import {TestEnvironment} from '../../utils/system';
-import {IDbmsInfo} from '../../models';
+import {DbmsManifestModel, IDbmsInfo} from '../../models';
 import {InvalidArgumentError, NotFoundError} from '../../errors';
 import {DBMS_MANIFEST_FILE} from '../../constants';
 
@@ -10,20 +10,22 @@ describe('LocalDbmss - link', () => {
     let app: TestEnvironment;
     let dbms: IDbmsInfo;
     let tmpDbmsPath: string;
+    let tmpDbmsPath2: string;
 
     beforeAll(async () => {
         app = await TestEnvironment.init(__filename);
         dbms = await app.createDbms();
         tmpDbmsPath = path.join(app.environment.dataPath, path.basename(dbms.rootPath!));
+        tmpDbmsPath2 = `${tmpDbmsPath}-2`;
 
-        await fse.remove(path.join(dbms.rootPath!, DBMS_MANIFEST_FILE));
-        await fse.move(dbms.rootPath!, tmpDbmsPath);
+        await fse.copy(dbms.rootPath!, tmpDbmsPath);
+        await fse.remove(path.join(tmpDbmsPath, DBMS_MANIFEST_FILE));
     });
 
     afterAll(() => app.teardown());
 
     test('Fails when linking bad path', async () => {
-        await expect(app.environment.dbmss.link('foo', '/path/to/nowhere')).rejects.toThrow(
+        await expect(app.environment.dbmss.link('/path/to/nowhere', 'foo')).rejects.toThrow(
             new InvalidArgumentError(
                 // eslint-disable-next-line max-len
                 'Path "/path/to/nowhere" does not seem to be a valid neo4j DBMS.\n\nSuggested Action(s):\n- Use a valid path',
@@ -31,8 +33,16 @@ describe('LocalDbmss - link', () => {
         );
     });
 
+    test('Fails when linking existing name', async () => {
+        await expect(app.environment.dbmss.link(tmpDbmsPath, dbms.name)).rejects.toThrow(
+            new InvalidArgumentError(
+                `DBMS "${dbms.name}" already exists.\n\nSuggested Action(s):\n- Use a unique name`,
+            ),
+        );
+    });
+
     test('Succeeds when linking correct path', async () => {
-        const result = await app.environment.dbmss.link('bar', tmpDbmsPath);
+        const result = await app.environment.dbmss.link(tmpDbmsPath, 'bar');
 
         expect(result.name).toEqual('bar');
     });
@@ -43,20 +53,47 @@ describe('LocalDbmss - link', () => {
         expect(result.name).toEqual('bar');
     });
 
-    test('Fails when linking existing name', async () => {
-        await expect(app.environment.dbmss.link('bar', tmpDbmsPath)).rejects.toThrow(
-            new InvalidArgumentError('DBMS "bar" already exists.\n\nSuggested Action(s):\n- Use a unique name'),
-        );
-    });
-
     test('Fails when linking already managed', async () => {
-        await expect(app.environment.dbmss.link('baz', tmpDbmsPath)).rejects.toThrow(
-            new InvalidArgumentError('DBMS "baz" already managed by relate'),
+        await expect(app.environment.dbmss.link(tmpDbmsPath, 'baz')).rejects.toThrow(
+            new InvalidArgumentError('DBMS "bar" already managed by relate'),
         );
     });
 
     test('Is not discovered if target is removed or missing', async () => {
-        await fse.remove(tmpDbmsPath);
+        await fse.move(tmpDbmsPath, tmpDbmsPath2);
+        await expect(app.environment.dbmss.get('bar')).rejects.toThrow(new NotFoundError('DBMS "bar" not found'));
+    });
+
+    test('Symlink is updated if linking again a DBMS that was moved', async () => {
+        const result = await app.environment.dbmss.link(tmpDbmsPath2, 'bar');
+        const targetPath = await fse.readlink(result.rootPath!);
+
+        expect(result.name).toEqual('bar');
+        expect(targetPath).toEqual(tmpDbmsPath2);
+    });
+
+    test('Target directory is not deleted when uninstalling', async () => {
+        const result = await app.environment.dbmss.uninstall('bar');
+        const targetPathExists = await fse.pathExists(tmpDbmsPath2);
+
+        expect(result.name).toEqual('bar');
+        expect(targetPathExists).toEqual(true);
+        await expect(app.environment.dbmss.get('bar')).rejects.toThrow(new NotFoundError('DBMS "bar" not found'));
+    });
+
+    test('Existing manifest is preferred over the given name', async () => {
+        const oldManifest = await fse.readJson(path.join(tmpDbmsPath2, DBMS_MANIFEST_FILE));
+        const newManifest = new DbmsManifestModel({
+            ...oldManifest,
+            name: 'foo',
+            tags: ['some tag'],
+        });
+        await fse.writeJson(path.join(tmpDbmsPath2, DBMS_MANIFEST_FILE), newManifest);
+
+        const result = await app.environment.dbmss.link(tmpDbmsPath2, 'bar');
+
+        expect(result.name).toEqual(newManifest.name);
+        expect(result.tags).toEqual(newManifest.tags);
         await expect(app.environment.dbmss.get('bar')).rejects.toThrow(new NotFoundError('DBMS "bar" not found'));
     });
 });

--- a/packages/common/src/entities/dbmss/link.test.ts
+++ b/packages/common/src/entities/dbmss/link.test.ts
@@ -69,7 +69,7 @@ describe('LocalDbmss - link', () => {
         const targetPath = await fse.readlink(result.rootPath!);
 
         expect(result.name).toEqual('bar');
-        expect(targetPath).toEqual(tmpDbmsPath2);
+        expect(targetPath.replace(/[/\\]$/, '')).toEqual(tmpDbmsPath2);
     });
 
     test('Target directory is not deleted when uninstalling', async () => {

--- a/packages/common/src/entities/dbmss/link.test.ts
+++ b/packages/common/src/entities/dbmss/link.test.ts
@@ -82,13 +82,13 @@ describe('LocalDbmss - link', () => {
     });
 
     test('Existing manifest is preferred over the given name', async () => {
-        const oldManifest = await fse.readJson(path.join(tmpDbmsPath2, DBMS_MANIFEST_FILE));
+        const oldManifest = await fse.readJSON(path.join(tmpDbmsPath2, DBMS_MANIFEST_FILE), {encoding: 'utf-8'});
         const newManifest = new DbmsManifestModel({
             ...oldManifest,
             name: 'foo',
             tags: ['some tag'],
         });
-        await fse.writeJson(path.join(tmpDbmsPath2, DBMS_MANIFEST_FILE), newManifest);
+        await fse.writeJson(path.join(tmpDbmsPath2, DBMS_MANIFEST_FILE), newManifest, {encoding: 'utf8'});
 
         const result = await app.environment.dbmss.link(tmpDbmsPath2, 'bar');
 

--- a/packages/common/src/entities/environments/environment.local.ts
+++ b/packages/common/src/entities/environments/environment.local.ts
@@ -20,6 +20,7 @@ import {LocalDbs} from '../dbs';
 import {LocalBackups} from '../backups';
 import {InvalidArgumentError} from '../../errors';
 import {TokenService} from '../../token.service';
+import {getManifestName} from '../../utils/system';
 
 export class LocalEnvironment extends EnvironmentAbstract {
     public readonly dbmss = new LocalDbmss(this);
@@ -65,6 +66,14 @@ export class LocalEnvironment extends EnvironmentAbstract {
             default:
                 throw new InvalidArgumentError(`Entity type ${entityType} is not stored on disk`);
         }
+    }
+
+    public entityExists(entityType: ENTITY_TYPES, id: string): Promise<boolean> {
+        // Need to check for the manifest instead of the project path, as broken
+        // links return inconsistent results across platforms (they behave as
+        // existing on Windows and non existing on Mac and Linux).
+        const manifestPath = path.join(this.getEntityRootPath(entityType, id), getManifestName(entityType));
+        return fse.pathExists(manifestPath);
     }
 
     async init(): Promise<void> {

--- a/packages/common/src/entities/manifest/manifest.local.ts
+++ b/packages/common/src/entities/manifest/manifest.local.ts
@@ -97,7 +97,7 @@ export class ManifestLocal<Entity extends IManifest, Manifest extends ManifestMo
             });
         }
 
-        const manifest = await fse.readJson(manifestPath);
+        const manifest = await fse.readJSON(manifestPath, {encoding: 'utf-8'});
         return new this.EntityModel({
             ...defaults,
             ...manifest,
@@ -114,6 +114,7 @@ export class ManifestLocal<Entity extends IManifest, Manifest extends ManifestMo
 
         await fse.ensureFile(manifestPath);
         await fse.writeJson(manifestPath, new this.EntityModel(updated.toObject()), {
+            encoding: 'utf8',
             spaces: 2,
         });
 

--- a/packages/common/src/entities/projects/link.test.ts
+++ b/packages/common/src/entities/projects/link.test.ts
@@ -92,13 +92,13 @@ describe('LocalProjects - link', () => {
     });
 
     test('Existing manifest is preferred over the given name', async () => {
-        const oldManifest = await fse.readJson(path.join(tmpPath2, PROJECT_MANIFEST_FILE));
+        const oldManifest = await fse.readJSON(path.join(tmpPath2, PROJECT_MANIFEST_FILE), {encoding: 'utf-8'});
         const newManifest = new DbmsManifestModel({
             ...oldManifest,
             name: 'foo',
             tags: ['some tag'],
         });
-        await fse.writeJson(path.join(tmpPath2, PROJECT_MANIFEST_FILE), newManifest);
+        await fse.writeJson(path.join(tmpPath2, PROJECT_MANIFEST_FILE), newManifest, {encoding: 'utf8'});
 
         const result = await environment.projects.link(tmpPath2, 'bar');
 

--- a/packages/common/src/entities/projects/link.test.ts
+++ b/packages/common/src/entities/projects/link.test.ts
@@ -1,0 +1,109 @@
+import fse from 'fs-extra';
+import path from 'path';
+
+import {TestDbmss} from '../../utils/system';
+import {DbmsManifestModel, IProject} from '../../models';
+import {InvalidArgumentError, NotFoundError} from '../../errors';
+import {PROJECT_MANIFEST_FILE} from '../../constants';
+import {EnvironmentAbstract} from '../environments';
+
+describe('LocalProjects - link', () => {
+    let environment: EnvironmentAbstract;
+    let testDbmss: TestDbmss;
+    let project: IProject;
+    let tmpPath: string;
+    let tmpPath2: string;
+
+    beforeAll(async () => {
+        testDbmss = await TestDbmss.init(__filename);
+        environment = testDbmss.environment;
+        project = await testDbmss.environment.projects.create({
+            name: __filename,
+        });
+
+        tmpPath = path.join(environment.dataPath, path.basename(project.root));
+        tmpPath2 = `${tmpPath}-2`;
+
+        await fse.copy(project.root, tmpPath);
+        await fse.remove(path.join(tmpPath, PROJECT_MANIFEST_FILE));
+    });
+
+    afterAll(async () => {
+        await fse.remove(tmpPath).catch(null);
+        await fse.remove(tmpPath2).catch(null);
+        await fse.remove(project.root).catch(null);
+    });
+
+    test('Fails when linking bad path', async () => {
+        await expect(environment.projects.link('/path/to/nowhere', 'foo')).rejects.toThrow(
+            new InvalidArgumentError(
+                // eslint-disable-next-line max-len
+                'Path "/path/to/nowhere" does not exist.\n\nSuggested Action(s):\n- Use a valid path',
+            ),
+        );
+    });
+
+    test('Fails when linking existing name', async () => {
+        await expect(environment.projects.link(tmpPath, project.name)).rejects.toThrow(
+            new InvalidArgumentError(
+                `Project "${project.name}" already exists.\n\nSuggested Action(s):\n- Use a unique name`,
+            ),
+        );
+    });
+
+    test('Succeeds when linking correct path', async () => {
+        const result = await environment.projects.link(tmpPath, 'bar');
+
+        expect(result.name).toEqual('bar');
+    });
+
+    test('Is correctly discovered after linking', async () => {
+        const result = await environment.projects.get('bar');
+
+        expect(result.name).toEqual('bar');
+    });
+
+    test('Fails when linking already managed', async () => {
+        await expect(environment.projects.link(tmpPath, 'baz')).rejects.toThrow(
+            new InvalidArgumentError('Project "bar" already managed by relate'),
+        );
+    });
+
+    test('Is not discovered if target is removed or missing', async () => {
+        await fse.move(tmpPath, tmpPath2);
+        await expect(environment.projects.get('bar')).rejects.toThrow(new NotFoundError('Could not find project bar'));
+    });
+
+    test('Symlink is updated if linking again a project that was moved', async () => {
+        const result = await environment.projects.link(tmpPath2, 'bar');
+        const targetPath = await fse.readlink(result.root);
+
+        expect(result.name).toEqual('bar');
+        expect(targetPath).toEqual(tmpPath2);
+    });
+
+    test('Target directory is not deleted when unlinking', async () => {
+        const result = await environment.projects.unlink('bar');
+        const targetPathExists = await fse.pathExists(tmpPath2);
+
+        expect(result.name).toEqual('bar');
+        expect(targetPathExists).toEqual(true);
+        await expect(environment.projects.get('bar')).rejects.toThrow(new NotFoundError('Could not find project bar'));
+    });
+
+    test('Existing manifest is preferred over the given name', async () => {
+        const oldManifest = await fse.readJson(path.join(tmpPath2, PROJECT_MANIFEST_FILE));
+        const newManifest = new DbmsManifestModel({
+            ...oldManifest,
+            name: 'foo',
+            tags: ['some tag'],
+        });
+        await fse.writeJson(path.join(tmpPath2, PROJECT_MANIFEST_FILE), newManifest);
+
+        const result = await environment.projects.link(tmpPath2, 'bar');
+
+        expect(result.name).toEqual(newManifest.name);
+        expect(result.tags).toEqual(newManifest.tags);
+        await expect(environment.projects.get('bar')).rejects.toThrow(new NotFoundError('Could not find project bar'));
+    });
+});

--- a/packages/common/src/entities/projects/link.test.ts
+++ b/packages/common/src/entities/projects/link.test.ts
@@ -79,7 +79,7 @@ describe('LocalProjects - link', () => {
         const targetPath = await fse.readlink(result.root);
 
         expect(result.name).toEqual('bar');
-        expect(targetPath).toEqual(tmpPath2);
+        expect(targetPath.replace(/[/\\]$/, '')).toEqual(tmpPath2);
     });
 
     test('Target directory is not deleted when unlinking', async () => {

--- a/packages/common/src/entities/projects/projects.abstract.ts
+++ b/packages/common/src/entities/projects/projects.abstract.ts
@@ -21,9 +21,8 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
     /**
      * Creates new project
      * @param   manifest        Project data
-     * @param   path            Path to project root
      */
-    abstract create(manifest: Omit<IProjectInput, 'id'>, path?: string): Promise<IProject>;
+    abstract create(manifest: Omit<IProjectInput, 'id'>): Promise<IProject>;
 
     /**
      * Gets a project by name
@@ -39,9 +38,10 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
 
     /**
      * Links an existing project
-     * @param   filePath    Path to project root
+     * @param   externalPath    Path to project root
+     * @param   name
      */
-    abstract link(filePath: string): Promise<IProject>;
+    abstract link(externalPath: string, name: string): Promise<IProject>;
 
     /**
      * Unlinks a linked project

--- a/packages/common/src/entities/projects/projects.abstract.ts
+++ b/packages/common/src/entities/projects/projects.abstract.ts
@@ -44,6 +44,12 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
     abstract link(filePath: string): Promise<IProject>;
 
     /**
+     * Unlinks a linked project
+     * @param   filePath    Path to project root
+     */
+    abstract unlink(nameOrID: string): Promise<IProject>;
+
+    /**
      * List files for given project
      * @param   projectId
      * @param   filters         Filters to apply

--- a/packages/common/src/entities/projects/projects.abstract.ts
+++ b/packages/common/src/entities/projects/projects.abstract.ts
@@ -27,9 +27,9 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
 
     /**
      * Gets a project by name
-     * @param   nameOrID
+     * @param   nameOrId
      */
-    abstract get(nameOrID: string): Promise<IProject>;
+    abstract get(nameOrId: string): Promise<IProject>;
 
     /**
      * List all available projects
@@ -45,39 +45,34 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
 
     /**
      * Unlinks a linked project
-     * @param   filePath    Path to project root
+     * @param   nameOrId
      */
-    abstract unlink(nameOrID: string): Promise<IProject>;
+    abstract unlink(nameOrId: string): Promise<IProject>;
 
     /**
      * List files for given project
-     * @param   projectId
+     * @param   nameOrId
      * @param   filters         Filters to apply
      */
-    abstract listFiles(projectId: string, filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IRelateFile>>;
+    abstract listFiles(nameOrId: string, filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IRelateFile>>;
 
     /**
      * Adds file (copy) to project
-     * @param   projectId
+     * @param   nameOrId
      * @param   source
      * @param   destination
      */
-    abstract addFile(
-        projectId: string,
-        source: string,
-        destination?: string,
-        overwrite?: boolean,
-    ): Promise<IRelateFile>;
+    abstract addFile(nameOrId: string, source: string, destination?: string, overwrite?: boolean): Promise<IRelateFile>;
 
     /**
      * Adds file (write) to project
-     * @param   projectId
+     * @param   nameOrId
      * @param   destination
      * @param   data
      * @param   writeFlag
      */
     abstract writeFile(
-        projectId: string,
+        nameOrId: string,
         destination: string,
         data: string | Buffer,
         writeFlag?: WriteFileFlag,
@@ -85,28 +80,28 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
 
     /**
      * Removes file from given project
-     * @param   projectId
+     * @param   nameOrId
      * @param   relativePath    Path relative to project
      */
-    abstract removeFile(projectId: string, relativePath: string): Promise<IRelateFile>;
+    abstract removeFile(nameOrId: string, relativePath: string): Promise<IRelateFile>;
 
     /**
      * Lists DBMSs for given project
-     * @param   projectId
+     * @param   nameOrId
      * @param   filters         Filters to apply
      */
-    abstract listDbmss(projectId: string, filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IProjectDbms>>;
+    abstract listDbmss(nameOrId: string, filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IProjectDbms>>;
 
     /**
      * Adds DBMS to given project
-     * @param   projectId
+     * @param   nameOrId        Project name or ID
      * @param   dbmsName        Name to give DBMS in project
      * @param   dbmsId
      * @param   principal       DBMS principal
      * @param   accessToken     DBMS access token
      */
     abstract addDbms(
-        projectId: string,
+        nameOrId: string,
         dbmsName: string,
         dbmsId: string,
         principal?: string,
@@ -115,8 +110,8 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
 
     /**
      * removes DBMS from given project
-     * @param   projectId
+     * @param   nameOrId        Project name or ID
      * @param   dbmsName
      */
-    abstract removeDbms(projectId: string, dbmsName: string): Promise<IProjectDbms>;
+    abstract removeDbms(nameOrId: string, dbmsName: string): Promise<IProjectDbms>;
 }

--- a/packages/common/src/entities/projects/projects.local.ts
+++ b/packages/common/src/entities/projects/projects.local.ts
@@ -158,13 +158,8 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
         return files.find(({name, directory}) => name === fileName && directory === projectDir);
     }
 
-    async addFile(
-        projectName: string,
-        source: string,
-        destination?: string,
-        overwrite?: boolean,
-    ): Promise<IRelateFile> {
-        const project = await this.get(projectName);
+    async addFile(nameOrId: string, source: string, destination?: string, overwrite?: boolean): Promise<IRelateFile> {
+        const project = await this.get(nameOrId);
         const target = getAbsoluteProjectPath(project, destination || path.basename(source));
         const projectDir = path.dirname(target);
         const fileName = path.basename(target);
@@ -190,12 +185,12 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
     }
 
     async writeFile(
-        projectName: string,
+        nameOrId: string,
         destination: string,
         data: string | Buffer,
         writeFlag?: WriteFileFlag,
     ): Promise<IRelateFile> {
-        const project = await this.get(projectName);
+        const project = await this.get(nameOrId);
         const filePath = getAbsoluteProjectPath(project, destination);
         const fileName = path.basename(filePath);
 
@@ -211,8 +206,8 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
         });
     }
 
-    async removeFile(projectName: string, relativePath: string): Promise<IRelateFile> {
-        const project = await this.get(projectName);
+    async removeFile(nameOrId: string, relativePath: string): Promise<IRelateFile> {
+        const project = await this.get(nameOrId);
         const maybeFile = await this.getFile(project, relativePath);
 
         return maybeFile.flatMap(async (file) => {
@@ -273,8 +268,8 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
         return newDbms;
     }
 
-    async removeDbms(projectName: string, dbmsName: string): Promise<IProjectDbms> {
-        const project = await this.get(projectName);
+    async removeDbms(nameOrId: string, dbmsName: string): Promise<IProjectDbms> {
+        const project = await this.get(nameOrId);
         const manifest = await this.manifest.get(project.id);
         const existing = List.from(manifest.dbmss);
 

--- a/packages/common/src/entities/projects/projects.local.ts
+++ b/packages/common/src/entities/projects/projects.local.ts
@@ -60,10 +60,12 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
             .mapEach((name) => name.replace(`${ENTITY_TYPES.PROJECT}-`, ''))
             .mapEach((projectId) =>
                 projectId.flatMap(async (id) => {
-                    const projectPath = this.environment.getEntityRootPath(ENTITY_TYPES.PROJECT, id);
-                    if (!(await fse.pathExists(projectPath))) {
+                    const projectExists = await this.environment.entityExists(ENTITY_TYPES.PROJECT, id);
+                    if (!projectExists) {
                         return null;
                     }
+
+                    const projectPath = this.environment.getEntityRootPath(ENTITY_TYPES.PROJECT, id);
                     const manifest = await this.manifest.get(id);
 
                     return {

--- a/packages/common/src/entities/projects/projects.local.ts
+++ b/packages/common/src/entities/projects/projects.local.ts
@@ -84,7 +84,7 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
         // If a manifest exists in the target path use it
         /* eslint-disable indent */
         const rawManifest = manifestExists
-            ? await fse.readJson(manifestPath)
+            ? await fse.readJSON(manifestPath, {encoding: 'utf-8'})
             : {
                   name,
                   id: uuidv4(),

--- a/packages/common/src/entities/projects/projects.local.ts
+++ b/packages/common/src/entities/projects/projects.local.ts
@@ -140,6 +140,15 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
         }
     }
 
+    async unlink(nameOrId: string): Promise<IProject> {
+        const project = await this.get(nameOrId);
+        const projectPath = this.environment.getEntityRootPath(ENTITY_TYPES.PROJECT, project.id);
+
+        await fse.unlink(projectPath);
+
+        return project;
+    }
+
     private async getFile(project: IProject, filePath: string): Promise<Maybe<IRelateFile>> {
         const target = getRelativeProjectPath(project, filePath);
         const fileName = path.basename(target);

--- a/packages/common/src/entities/projects/projects.remote.ts
+++ b/packages/common/src/entities/projects/projects.remote.ts
@@ -16,7 +16,7 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         (nameOrId: string) => this.get(nameOrId),
     );
 
-    create(_manifest: IProjectInput): Promise<IProject> {
+    create(_manifest: Omit<IProjectInput, 'id'>): Promise<IProject> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support creating projects`);
     }
 
@@ -28,7 +28,7 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support listing projects`);
     }
 
-    link(_filePath: string): Promise<IProject> {
+    link(_externalPath: string, _name: string): Promise<IProject> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support linking projects`);
     }
 

--- a/packages/common/src/entities/projects/projects.remote.ts
+++ b/packages/common/src/entities/projects/projects.remote.ts
@@ -20,7 +20,7 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support creating projects`);
     }
 
-    get(_name: string): Promise<IProject> {
+    get(_nameOrId: string): Promise<IProject> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support getting projects`);
     }
 
@@ -40,7 +40,7 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support listing project files`);
     }
 
-    addFile(_name: string, _source: string, _destination?: string, _overwrite?: boolean): Promise<IRelateFile> {
+    addFile(_nameOrId: string, _source: string, _destination?: string, _overwrite?: boolean): Promise<IRelateFile> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support adding project files`);
     }
 
@@ -48,7 +48,7 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support writing to project files`);
     }
 
-    removeFile(_name: string, _relativePath: string): Promise<IRelateFile> {
+    removeFile(_nameOrId: string, _relativePath: string): Promise<IRelateFile> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support removing project files`);
     }
 
@@ -57,7 +57,7 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
     }
 
     addDbms(
-        _name: string,
+        _nameOrId: string,
         _dbmsName: string,
         _dbmsId: string,
         _principal?: string,
@@ -66,7 +66,7 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support adding project dbms`);
     }
 
-    removeDbms(_name: string, _dbmsName: string): Promise<IProjectDbms> {
+    removeDbms(_nameOrId: string, _dbmsName: string): Promise<IProjectDbms> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support removing project dbms`);
     }
 }

--- a/packages/common/src/entities/projects/projects.remote.ts
+++ b/packages/common/src/entities/projects/projects.remote.ts
@@ -32,6 +32,10 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support linking projects`);
     }
 
+    unlink(_nameOrId: string): Promise<IProject> {
+        throw new NotSupportedError(`${RemoteProjects.name} does not support unlinking projects`);
+    }
+
     listFiles(_nameOrId: string, _filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IRelateFile>> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support listing project files`);
     }

--- a/packages/common/src/system/system.provider.ts
+++ b/packages/common/src/system/system.provider.ts
@@ -146,7 +146,10 @@ export class SystemProvider implements OnModuleInit {
         });
         const environment = await createEnvironmentInstance(configModel);
 
-        await fse.writeJSON(filePath, configModel, {spaces: 2});
+        await fse.writeJSON(filePath, configModel, {
+            encoding: 'utf-8',
+            spaces: 2,
+        });
         this.allEnvironments.setValue(environment.id, environment);
 
         return environment;

--- a/packages/common/src/utils/extensions/extension-versions.ts
+++ b/packages/common/src/utils/extensions/extension-versions.ts
@@ -57,7 +57,7 @@ export async function discoverExtension(extensionRootDir: string): Promise<Exten
         throw new InvalidArgumentError(`${dirName} contains no package.json`);
     }
 
-    const packageJson = await fse.readJSON(extensionPackageJson);
+    const packageJson = await fse.readJSON(extensionPackageJson, {encoding: 'utf-8'});
     const appResult = await verifyApp({
         appPath: extensionRootDir,
         rootCertificatePem: RELATE_ROOT_CERT,
@@ -83,7 +83,7 @@ export async function discoverExtension(extensionRootDir: string): Promise<Exten
 
     const manifest = await defaultManifest.switchMap(async (m) => {
         if (hasManifestFile) {
-            return defaultManifest.merge(await fse.readJSON(extensionManifest));
+            return defaultManifest.merge(await fse.readJSON(extensionManifest, {encoding: 'utf-8'}));
         }
 
         if (_.has(packageJson, EXTENSION_MANIFEST_KEY)) {

--- a/packages/common/src/utils/system/test-extensions.ts
+++ b/packages/common/src/utils/system/test-extensions.ts
@@ -70,8 +70,8 @@ export class TestExtensions {
         await fse.ensureFile(manifestPath);
         await fse.ensureFile(packageJsonPath);
         await fse.ensureFile(indexPath);
-        await fse.writeJSON(manifestPath, manifest);
-        await fse.writeJSON(packageJsonPath, packageJson);
+        await fse.writeJSON(manifestPath, manifest, {encoding: 'utf8'});
+        await fse.writeJSON(packageJsonPath, packageJson, {encoding: 'utf8'});
 
         if (type === EXTENSION_TYPES.STATIC && !cached) {
             await fse.ensureDir(path.join(extensionPath, type));

--- a/packages/types/documentation/classes/dict.md
+++ b/packages/types/documentation/classes/dict.md
@@ -231,11 +231,11 @@ ___
 
 ###  omit
 
-▸ **omit**‹**K2**, **R**›(`other`: K2): *[Dict](dict.md)‹R›*
+▸ **omit**‹**K2**, **R**›(...`other`: K2[]): *[Dict](dict.md)‹R›*
 
 *Defined in [src/monads/primitive/dict.monad.ts:202](https://github.com/neo4j-devtools/relate/blob/master/packages/types/src/monads/primitive/dict.monad.ts#L202)*
 
-Omits a key from the Dict
+Omits one or more keys from the Dict
 ```ts
 const fooBar = Dict.from({foo: true, bar: 1});
 const foo = fooBar.omit('bar');
@@ -252,15 +252,15 @@ foo.toObject() // {foo: true}
 
 Name | Type |
 ------ | ------ |
-`other` | K2 |
+`...other` | K2[] |
 
 **Returns:** *[Dict](dict.md)‹R›*
 
-▸ **omit**‹**K2**, **I**, **R**›(`other`: K2): *R*
+▸ **omit**‹**K2**, **I**, **R**›(...`other`: K2[]): *R*
 
 *Defined in [src/monads/primitive/dict.monad.ts:204](https://github.com/neo4j-devtools/relate/blob/master/packages/types/src/monads/primitive/dict.monad.ts#L204)*
 
-Omits a key from the Dict
+Omits one or more keys from the Dict
 ```ts
 const fooBar = Dict.from({foo: true, bar: 1});
 const foo = fooBar.omit('bar');
@@ -279,7 +279,7 @@ foo.toObject() // {foo: true}
 
 Name | Type |
 ------ | ------ |
-`other` | K2 |
+`...other` | K2[] |
 
 **Returns:** *R*
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fixes and some minor features

### What is the current behavior?
  - There is no way to unlink a project.
  - `project.create` creates a project in some cases and links an existing project in other cases.
  - `project.link` expects a manifest to exist.
  - `projects.list` shows broken links as existing projects.
  - Linking a DBMS/project containing a manifest with a duplicate name works, causing errors when trying to retrieve that entity.
  - Linking a DBMS/project containing an invalid manifest works, causing errors later on when trying to retrieve that entity.
  - Broken symlinks on Windows no prevent DBMSs/projects from being linked in the same location.

### What is the new behavior?
  - added `projects.unlink` to unlink a linked project.
  - `project.create` no longer links a project folder.
  - `project.link` now creates the manifest if it doesn't exist.
  - `projects.list` no longer shows broken links.
  - Linking a DBMS/project containing a manifest with a duplicate name fails.
  - Linking a DBMS/project containing an invalid manifest fails.
  - Broken symlinks on Windows no longer prevent a DBMS/project from being linked in the same location.
  - More behaviors are tested in both `projects.link` and `dbmss.link`

### Does this PR introduce a breaking change?
Yes. Some errors that were swallowed and later caused problems now throw right away. The methods below also changed.
|                    | Args before                                            | Args after                         |
| --------------- | ------------------------------------------------------ | ---------------------------------- |
| projects.create | manifest: Omit<IProjectInput, 'id'>, targetDir: string | manifest: Omit<IProjectInput, 'id'> |
| projects.link   | filePath: string                                       | externalPath: string, name: string |
| dbmss.link      | name: string, rootPath : string                        | externalPath: string, name: string |



### Other information:
For the refactored methods it's probably easier to just read the updated versions instead of the diff:
- [projects.link](https://github.com/neo4j-devtools/relate/blob/8fb4df205528b9f80135bcef30f360204976e9dc/packages/common/src/entities/projects/projects.local.ts#L74-L122)
- [dbmss.link](https://github.com/neo4j-devtools/relate/blob/8fb4df205528b9f80135bcef30f360204976e9dc/packages/common/src/entities/dbmss/dbmss.local.ts#L296-L351)