### PR TITLE
Start running tests in separate environments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -172,6 +172,10 @@
             {
                 "selector": "NewExpression[callee.name='TestDbmss']",
                 "message": "Do not use 'new TestDbmss()', use 'TestDbmss.init()' instead."
+            },
+            {
+                "selector": "NewExpression[callee.name='TestEnvironment']",
+                "message": "Do not use 'new TestEnvironment()', use 'TestEnvironment.init()' instead."
             }
         ],
         "no-restricted-properties": [

--- a/packages/common/src/entities/dbmss/install.test.ts
+++ b/packages/common/src/entities/dbmss/install.test.ts
@@ -4,57 +4,57 @@ import {List} from '@relate/types';
 import {InvalidArgumentError, NotFoundError, NotSupportedError} from '../../errors';
 import * as versionUtils from '../../utils/dbmss/dbms-versions';
 import * as downloadUtils from '../../utils/dbmss/download-neo4j';
-import {TestDbmss} from '../../utils/system';
+import {TestDbmss, TestEnvironment} from '../../utils/system';
 import {DBMS_DIR_NAME, DBMS_STATUS} from '../../constants';
-import {EnvironmentAbstract} from '../environments';
+import {LocalEnvironment} from '../environments';
 
 const UUID_REGEX = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
 const {ARCHIVE_PATH, NEO4J_VERSION} = TestDbmss;
 
 describe('LocalDbmss - install', () => {
-    let testDbmss: TestDbmss;
-    let testEnv: EnvironmentAbstract;
+    let app: TestEnvironment;
+    let testEnv: LocalEnvironment;
 
     beforeAll(async () => {
-        testDbmss = await TestDbmss.init(__filename);
-        testEnv = testDbmss.environment;
+        app = await TestEnvironment.init(__filename);
+        testEnv = app.environment;
     });
 
-    afterAll(() => testDbmss.teardown());
+    afterAll(() => app.teardown());
 
     afterEach(() => jest.restoreAllMocks());
 
     test('with no version', async () => {
-        await expect(testDbmss.environment.dbmss.install(testDbmss.createName(), '')).rejects.toThrow(
+        await expect(testEnv.dbmss.install(app.createName(), '')).rejects.toThrow(
             new InvalidArgumentError('Version must be specified'),
         );
     });
 
     test('with invalid version', async () => {
-        await expect(
-            testDbmss.environment.dbmss.install(testDbmss.createName(), 'notAVersionUrlOrFilePath'),
-        ).rejects.toThrow(new InvalidArgumentError('Provided version argument is not valid semver, url or path.'));
+        await expect(testEnv.dbmss.install(app.createName(), 'notAVersionUrlOrFilePath')).rejects.toThrow(
+            new InvalidArgumentError('Provided version argument is not valid semver, url or path.'),
+        );
     });
 
     test('with valid version (URL)', async () => {
-        await expect(
-            testDbmss.environment.dbmss.install(testDbmss.createName(), 'https://valid.url.com'),
-        ).rejects.toThrow(new NotSupportedError('fetch and install https://valid.url.com'));
+        await expect(testEnv.dbmss.install(app.createName(), 'https://valid.url.com')).rejects.toThrow(
+            new NotSupportedError('fetch and install https://valid.url.com'),
+        );
     });
 
     test('with not existing version (file path)', async () => {
         const message = 'Provided version argument is not valid semver, url or path.';
 
-        await expect(
-            testDbmss.environment.dbmss.install(testDbmss.createName(), path.join('non', 'existing', 'path')),
-        ).rejects.toThrow(new InvalidArgumentError(message));
+        await expect(testEnv.dbmss.install(app.createName(), path.join('non', 'existing', 'path'))).rejects.toThrow(
+            new InvalidArgumentError(message),
+        );
     });
 
     test('with valid version (file path)', async () => {
-        const {id: dbmsID} = await testDbmss.environment.dbmss.install(testDbmss.createName(), ARCHIVE_PATH);
+        const {id: dbmsID} = await testEnv.dbmss.install(app.createName(), ARCHIVE_PATH);
         expect(dbmsID).toMatch(UUID_REGEX);
 
-        const message = await testDbmss.environment.dbmss.get(dbmsID);
+        const message = await testEnv.dbmss.get(dbmsID);
         expect(message.status).toContain(DBMS_STATUS.STOPPED);
 
         const info = await versionUtils.getDistributionInfo(
@@ -64,7 +64,7 @@ describe('LocalDbmss - install', () => {
     });
 
     test('with version in unsupported range (semver)', async () => {
-        await expect(testDbmss.environment.dbmss.install(testDbmss.createName(), '3.1')).rejects.toThrow(
+        await expect(testEnv.dbmss.install(app.createName(), '3.1')).rejects.toThrow(
             new NotSupportedError('version not in range >=3.4'),
         );
     });
@@ -76,11 +76,11 @@ describe('LocalDbmss - install', () => {
             .mockImplementationOnce(() => Promise.resolve(List.from([])));
         jest.spyOn(downloadUtils, 'downloadNeo4j').mockImplementation(() => Promise.resolve());
 
-        const {id: dbmsId} = await testDbmss.environment.dbmss.install(testDbmss.createName(), NEO4J_VERSION);
+        const {id: dbmsId} = await testEnv.dbmss.install(app.createName(), NEO4J_VERSION);
 
         expect(discoverNeo4jDistributionsSpy).toHaveBeenCalledTimes(2);
 
-        const message = (await testDbmss.environment.dbmss.info([dbmsId])).toArray();
+        const message = (await testEnv.dbmss.info([dbmsId])).toArray();
         expect(message[0].status).toContain(DBMS_STATUS.STOPPED);
 
         const info = await versionUtils.getDistributionInfo(
@@ -94,15 +94,15 @@ describe('LocalDbmss - install', () => {
         jest.spyOn(versionUtils, 'discoverNeo4jDistributions').mockImplementation(() => Promise.resolve(List.from([])));
         jest.spyOn(downloadUtils, 'downloadNeo4j').mockImplementation(() => Promise.resolve());
 
-        await expect(testDbmss.environment.dbmss.install(testDbmss.createName(), NEO4J_VERSION)).rejects.toThrow(
+        await expect(testEnv.dbmss.install(app.createName(), NEO4J_VERSION)).rejects.toThrow(
             new NotFoundError(message),
         );
     });
 
     test('with valid version (semver)', async () => {
-        const {id: dbmsId} = await testDbmss.environment.dbmss.install(testDbmss.createName(), NEO4J_VERSION);
+        const {id: dbmsId} = await testEnv.dbmss.install(app.createName(), NEO4J_VERSION);
 
-        const message = (await testDbmss.environment.dbmss.info([dbmsId])).toArray();
+        const message = (await testEnv.dbmss.info([dbmsId])).toArray();
         expect(message[0].status).toContain(DBMS_STATUS.STOPPED);
 
         const info = await versionUtils.getDistributionInfo(
@@ -110,9 +110,9 @@ describe('LocalDbmss - install', () => {
         );
         expect(info?.version).toEqual(NEO4J_VERSION);
 
-        const {id: dbmsId2} = await testDbmss.environment.dbmss.install(testDbmss.createName(), NEO4J_VERSION);
+        const {id: dbmsId2} = await testEnv.dbmss.install(app.createName(), NEO4J_VERSION);
 
-        const message2 = (await testDbmss.environment.dbmss.info([dbmsId2])).toArray();
+        const message2 = (await testEnv.dbmss.info([dbmsId2])).toArray();
         expect(message2[0].status).toContain(DBMS_STATUS.STOPPED);
 
         const info2 = await versionUtils.getDistributionInfo(
@@ -122,8 +122,8 @@ describe('LocalDbmss - install', () => {
     });
 
     test('Has valid neo4j.conf, without leading commas in values', async () => {
-        const {id: dbmsId} = await testDbmss.environment.dbmss.install(testDbmss.createName(), NEO4J_VERSION);
-        const config = await testDbmss.environment.dbmss.getDbmsConfig(dbmsId);
+        const {id: dbmsId} = await testEnv.dbmss.install(app.createName(), NEO4J_VERSION);
+        const config = await testEnv.dbmss.getDbmsConfig(dbmsId);
 
         expect(config.get('dbms.security.procedures.unrestricted')).toEqual('jwt.security.*');
     });

--- a/packages/common/src/entities/dbmss/link.test.ts
+++ b/packages/common/src/entities/dbmss/link.test.ts
@@ -1,27 +1,29 @@
 import fse from 'fs-extra';
 import path from 'path';
 
-import {TestDbmss} from '../../utils/system';
+import {TestEnvironment} from '../../utils/system';
 import {IDbmsInfo} from '../../models';
 import {InvalidArgumentError, NotFoundError} from '../../errors';
 import {DBMS_MANIFEST_FILE} from '../../constants';
 
 describe('LocalDbmss - link', () => {
-    let testDbmss: TestDbmss;
-    let instance: IDbmsInfo;
+    let app: TestEnvironment;
+    let dbms: IDbmsInfo;
     let tmpDbmsPath: string;
 
     beforeAll(async () => {
-        testDbmss = await TestDbmss.init(__filename);
-        instance = await testDbmss.createDbms();
-        tmpDbmsPath = path.join(testDbmss.environment.dataPath, path.basename(instance.rootPath!));
+        app = await TestEnvironment.init(__filename);
+        dbms = await app.createDbms();
+        tmpDbmsPath = path.join(app.environment.dataPath, path.basename(dbms.rootPath!));
 
-        await fse.remove(path.join(instance.rootPath!, DBMS_MANIFEST_FILE));
-        await fse.move(instance.rootPath!, tmpDbmsPath);
+        await fse.remove(path.join(dbms.rootPath!, DBMS_MANIFEST_FILE));
+        await fse.move(dbms.rootPath!, tmpDbmsPath);
     });
 
+    afterAll(() => app.teardown());
+
     test('Fails when linking bad path', async () => {
-        await expect(testDbmss.environment.dbmss.link('foo', '/path/to/nowhere')).rejects.toThrow(
+        await expect(app.environment.dbmss.link('foo', '/path/to/nowhere')).rejects.toThrow(
             new InvalidArgumentError(
                 // eslint-disable-next-line max-len
                 'Path "/path/to/nowhere" does not seem to be a valid neo4j DBMS.\n\nSuggested Action(s):\n- Use a valid path',
@@ -30,31 +32,31 @@ describe('LocalDbmss - link', () => {
     });
 
     test('Succeeds when linking correct path', async () => {
-        const result = await testDbmss.environment.dbmss.link('bar', tmpDbmsPath);
+        const result = await app.environment.dbmss.link('bar', tmpDbmsPath);
 
         expect(result.name).toEqual('bar');
     });
 
     test('Is correctly discovered after linking', async () => {
-        const result = await testDbmss.environment.dbmss.get('bar');
+        const result = await app.environment.dbmss.get('bar');
 
         expect(result.name).toEqual('bar');
     });
 
     test('Fails when linking existing name', async () => {
-        await expect(testDbmss.environment.dbmss.link('bar', tmpDbmsPath)).rejects.toThrow(
+        await expect(app.environment.dbmss.link('bar', tmpDbmsPath)).rejects.toThrow(
             new InvalidArgumentError('DBMS "bar" already exists.\n\nSuggested Action(s):\n- Use a unique name'),
         );
     });
 
     test('Fails when linking already managed', async () => {
-        await expect(testDbmss.environment.dbmss.link('baz', tmpDbmsPath)).rejects.toThrow(
+        await expect(app.environment.dbmss.link('baz', tmpDbmsPath)).rejects.toThrow(
             new InvalidArgumentError('DBMS "baz" already managed by relate'),
         );
     });
 
     test('Is not discovered if target is removed or missing', async () => {
         await fse.remove(tmpDbmsPath);
-        await expect(testDbmss.environment.dbmss.get('bar')).rejects.toThrow(new NotFoundError('DBMS "bar" not found'));
+        await expect(app.environment.dbmss.get('bar')).rejects.toThrow(new NotFoundError('DBMS "bar" not found'));
     });
 });

--- a/packages/common/src/entities/dbmss/manifest.local.test.ts
+++ b/packages/common/src/entities/dbmss/manifest.local.test.ts
@@ -3,24 +3,21 @@ import fse from 'fs-extra';
 import path from 'path';
 
 import {DbmsManifestModel, IDbmsInfo} from '../../models';
-import {TestDbmss} from '../../utils/system';
-import {EnvironmentAbstract} from '../environments';
+import {TestEnvironment} from '../../utils/system';
 
 describe('LocalDbmss - manifest', () => {
     const nonExistentId = uuid();
-    let environment: EnvironmentAbstract;
-    let testDbmss: TestDbmss;
+    let app: TestEnvironment;
     let dbms: IDbmsInfo;
 
     beforeAll(async () => {
-        testDbmss = await TestDbmss.init(__filename);
-        environment = testDbmss.environment;
-        dbms = await testDbmss.createDbms();
+        app = await TestEnvironment.init(__filename);
+        dbms = await app.createDbms();
     });
 
     afterAll(async () => {
-        await fse.remove(path.join(environment.dirPaths.dbmssData, `dbms-${nonExistentId}`));
-        await testDbmss.teardown();
+        await fse.remove(path.join(app.environment.dirPaths.dbmssData, `dbms-${nonExistentId}`));
+        await app.teardown();
     });
 
     test('get manifest of existing DBMS', async () => {
@@ -30,7 +27,7 @@ describe('LocalDbmss - manifest', () => {
             description: '',
             tags: [],
         });
-        const manifest = await environment.dbmss.manifest.get(dbms.id);
+        const manifest = await app.environment.dbmss.manifest.get(dbms.id);
 
         expect(manifest).toEqual(expected);
     });
@@ -43,10 +40,10 @@ describe('LocalDbmss - manifest', () => {
             tags: [],
         });
 
-        await environment.dbmss.manifest.update(dbms.id, {
+        await app.environment.dbmss.manifest.update(dbms.id, {
             description: 'some description',
         });
-        const manifest = await environment.dbmss.manifest.get(dbms.id);
+        const manifest = await app.environment.dbmss.manifest.get(dbms.id);
 
         expect(manifest).toEqual(expected);
     });
@@ -59,8 +56,8 @@ describe('LocalDbmss - manifest', () => {
             tags: ['tag1', 'tag2', 'tag3'],
         });
 
-        const newDbms = await environment.dbmss.manifest.addTags(dbms.id, ['tag1', 'tag2', 'tag3']);
-        const manifest = await environment.dbmss.manifest.get(dbms.id);
+        const newDbms = await app.environment.dbmss.manifest.addTags(dbms.id, ['tag1', 'tag2', 'tag3']);
+        const manifest = await app.environment.dbmss.manifest.get(dbms.id);
 
         expect(newDbms.tags).toEqual(expected.tags);
         expect(manifest).toEqual(expected);
@@ -74,8 +71,8 @@ describe('LocalDbmss - manifest', () => {
             tags: ['tag1', 'tag3'],
         });
 
-        const newDbms = await environment.dbmss.manifest.removeTags(dbms.id, ['tag2']);
-        const manifest = await environment.dbmss.manifest.get(dbms.id);
+        const newDbms = await app.environment.dbmss.manifest.removeTags(dbms.id, ['tag2']);
+        const manifest = await app.environment.dbmss.manifest.get(dbms.id);
 
         expect(newDbms.tags).toEqual(expected.tags);
         expect(manifest).toEqual(expected);
@@ -96,10 +93,10 @@ describe('LocalDbmss - manifest', () => {
             },
         });
 
-        await environment.dbmss.manifest.setMetadata(dbms.id, 'object', {foo: 'bar'});
-        await environment.dbmss.manifest.setMetadata(dbms.id, 'number', 42);
-        const updatedDbms = await environment.dbmss.manifest.setMetadata(dbms.id, 'string', 'foo');
-        const manifest = await environment.dbmss.manifest.get(dbms.id);
+        await app.environment.dbmss.manifest.setMetadata(dbms.id, 'object', {foo: 'bar'});
+        await app.environment.dbmss.manifest.setMetadata(dbms.id, 'number', 42);
+        const updatedDbms = await app.environment.dbmss.manifest.setMetadata(dbms.id, 'string', 'foo');
+        const manifest = await app.environment.dbmss.manifest.get(dbms.id);
 
         expect(updatedDbms.metadata).toEqual(expected.metadata);
         expect(manifest).toEqual(expected);
@@ -114,8 +111,13 @@ describe('LocalDbmss - manifest', () => {
             metadata: {string: 'foo'},
         });
 
-        const updatedDbms = await environment.dbmss.manifest.removeMetadata(dbms.id, 'object', 'number', 'nonexistent');
-        const manifest = await environment.dbmss.manifest.get(dbms.id);
+        const updatedDbms = await app.environment.dbmss.manifest.removeMetadata(
+            dbms.id,
+            'object',
+            'number',
+            'nonexistent',
+        );
+        const manifest = await app.environment.dbmss.manifest.get(dbms.id);
 
         expect(updatedDbms.metadata).toEqual(expected.metadata);
         expect(manifest).toEqual(expected);
@@ -129,11 +131,11 @@ describe('LocalDbmss - manifest', () => {
             tags: [],
         });
 
-        await environment.dbmss.manifest.update(nonExistentId, {
+        await app.environment.dbmss.manifest.update(nonExistentId, {
             name: 'a new dbms',
             description: 'with a new description',
         });
-        const manifest = await environment.dbmss.manifest.get(nonExistentId);
+        const manifest = await app.environment.dbmss.manifest.get(nonExistentId);
 
         expect(manifest).toEqual(expected);
     });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,7 +1,7 @@
 export {IAuthToken} from '@huboneo/tapestry';
 // @todo: better way of handling types
 export {IExtensionVersion, loadExtensionsFor, getAppLaunchUrl} from './utils/extensions';
-export {TestDbmss, TestExtensions} from './utils/system';
+export {TestDbmss, TestExtensions, TestEnvironment} from './utils/system';
 export * from './system';
 export * from './models';
 export * from './errors';

--- a/packages/common/src/utils/system/index.ts
+++ b/packages/common/src/utils/system/index.ts
@@ -2,3 +2,4 @@ export {createEnvironmentInstance} from './create-environment-instance';
 export {getManifestName} from './get-manifest-name';
 export {TestDbmss} from './test-dbmss';
 export {TestExtensions} from './test-extensions';
+export * from './test-environment';

--- a/packages/common/src/utils/system/test-environment.ts
+++ b/packages/common/src/utils/system/test-environment.ts
@@ -1,0 +1,74 @@
+import {INestApplicationContext, Module} from '@nestjs/common';
+import {ConfigModule} from '@nestjs/config';
+import {NestFactory} from '@nestjs/core';
+import {Dict} from '@relate/types';
+import fse from 'fs-extra';
+import path from 'path';
+import {v4 as uuid} from 'uuid';
+
+import {ENVIRONMENT_TYPES, LocalEnvironment, NEO4J_EDITION} from '../../entities/environments';
+import {IDbmsInfo} from '../../models';
+import {SystemModule, SystemProvider} from '../../system';
+
+export const TEST_NEO4J_VERSION = process.env.TEST_NEO4J_VERSION || '4.0.4';
+export const TEST_NEO4J_EDITION: NEO4J_EDITION = Dict.from(NEO4J_EDITION)
+    .values.find((e) => e === process.env.TEST_NEO4J_EDITION)
+    .getOrElse(NEO4J_EDITION.ENTERPRISE);
+
+export class TestEnvironment {
+    constructor(
+        public readonly filename: string,
+        public readonly app: INestApplicationContext,
+        public readonly systemProvider: SystemProvider,
+        public readonly environment: LocalEnvironment,
+    ) {}
+
+    static async init(filename: string): Promise<TestEnvironment> {
+        const shortUUID = uuid().slice(0, 8);
+        const dirname = path.basename(path.dirname(filename));
+        const name = `${dirname}_${path.basename(filename, '.ts')}_${shortUUID}`;
+
+        @Module({
+            imports: [
+                ConfigModule.forRoot({
+                    isGlobal: true,
+                }),
+                SystemModule.register(),
+            ],
+        })
+        class AppModule {}
+
+        const app = await NestFactory.createApplicationContext(AppModule);
+
+        const systemProvider = app.get(SystemProvider);
+        await systemProvider.createEnvironment({
+            name,
+            type: ENVIRONMENT_TYPES.LOCAL,
+        });
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        const environment: LocalEnvironment = await systemProvider.getEnvironment(name);
+        return new TestEnvironment(filename, app, systemProvider, environment);
+    }
+
+    async teardown(): Promise<void> {
+        const dbmss = await this.environment.dbmss.list();
+        const dbmsIds = dbmss.mapEach((dbms) => dbms.id);
+
+        await this.environment.dbmss.stop(dbmsIds);
+        await dbmsIds.mapEach((dbmsId) => this.environment.dbmss.uninstall(dbmsId)).unwindPromises();
+
+        await fse.remove(this.environment.dataPath);
+        await fse.remove(this.environment.configPath);
+    }
+
+    createName(): string {
+        const shortUUID = uuid().slice(0, 8);
+        return `[${shortUUID}] ${path.relative('..', this.filename)}`;
+    }
+
+    createDbms(): Promise<IDbmsInfo> {
+        return this.environment.dbmss.install(this.createName(), TEST_NEO4J_VERSION, TEST_NEO4J_EDITION);
+    }
+}

--- a/packages/common/src/utils/system/test-environment.ts
+++ b/packages/common/src/utils/system/test-environment.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import {v4 as uuid} from 'uuid';
 
 import {ENVIRONMENT_TYPES, LocalEnvironment, NEO4J_EDITION} from '../../entities/environments';
+import {NotSupportedError} from '../../errors';
 import {IDbmsInfo} from '../../models';
 import {SystemModule, SystemProvider} from '../../system';
 
@@ -21,7 +22,11 @@ export class TestEnvironment {
         public readonly app: INestApplicationContext,
         public readonly systemProvider: SystemProvider,
         public readonly environment: LocalEnvironment,
-    ) {}
+    ) {
+        if (process.env.NODE_ENV !== 'test') {
+            throw new NotSupportedError('Cannot use TestEnvironment outside of testing environment');
+        }
+    }
 
     static async init(filename: string): Promise<TestEnvironment> {
         const shortUUID = uuid().slice(0, 8);
@@ -49,6 +54,8 @@ export class TestEnvironment {
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
         const environment: LocalEnvironment = await systemProvider.getEnvironment(name);
+
+        // eslint-disable-next-line no-restricted-syntax
         return new TestEnvironment(filename, app, systemProvider, environment);
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Reduce flaky tests.


### What is the current behavior?
Tests are really flaky. Each time you run them a different test is failing, with either an error about a missing file or about invalid JSON when reading from a JSON file. 

### What is the new behavior?
A new util called `TestEnvironment` is now available to make test suites run in separate environments. This simplifies the teardown logic and reduces the chance of having different test suites interfering with each other. The intent is to later replace all uses of `TestDbmss` and `TestExtensions` with it.


### Does this PR introduce a breaking change?
No


### Other information:
