### PR TITLE
Add resolvers for getting/setting/removing metadata and tags

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -134,6 +134,8 @@ export enum PUBLIC_GRAPHQL_METHODS {
     UPDATE_DBMS_CONFIG = 'updateDbmsConfig',
     ADD_DBMS_TAGS = 'addDbmsTags',
     REMOVE_DBMS_TAGS = 'removeDbmsTags',
+    SET_DBMS_METADATA = 'setDbmsMetadata',
+    REMOVE_DBMS_METADATA = 'removeDbmsMetadata',
 
     // dbs
     CREATE_DB = 'createDb',
@@ -157,6 +159,10 @@ export enum PUBLIC_GRAPHQL_METHODS {
     REMOVE_PROJECT_DBMS = 'removeProjectDbms',
     ADD_PROJECT_FILE = 'addProjectFile',
     REMOVE_PROJECT_FILE = 'removeProjectFile',
+    ADD_PROJECT_TAGS = 'addProjectTags',
+    REMOVE_PROJECT_TAGS = 'removeProjectTags',
+    SET_PROJECT_METADATA = 'setProjectMetadata',
+    REMOVE_PROJECT_METADATA = 'removeProjectMetadata',
 
     // dump / import
     DB_DUMP = 'dbDump',

--- a/packages/common/src/entities/environments/environment.constants.ts
+++ b/packages/common/src/entities/environments/environment.constants.ts
@@ -44,6 +44,7 @@ export const NEO4J_DIST_LIMITED_VERSIONS_URL = 'https://dist.neo4j.org/versions/
 export const NEO4J_CONF_DIR = 'conf';
 export const NEO4J_LOGS_DIR = 'logs';
 export const NEO4J_DATA_DIR = 'data';
+export const NEO4J_IMPORT_DIR = 'import';
 export const NEO4J_RUN_DIR = 'run';
 export const NEO4J_LIB_DIR = 'lib';
 export const NEO4J_PLUGIN_DIR = 'plugins';

--- a/packages/common/src/utils/dbmss/dbms-upgrade-config.ts
+++ b/packages/common/src/utils/dbmss/dbms-upgrade-config.ts
@@ -7,6 +7,7 @@ import {
     NEO4J_CERT_DIR,
     NEO4J_CONF_DIR,
     NEO4J_DATA_DIR,
+    NEO4J_IMPORT_DIR,
     NEO4J_JWT_ADDON_NAME,
     NEO4J_JWT_ADDON_VERSION,
     NEO4J_JWT_CONF_FILE,
@@ -41,6 +42,7 @@ export async function dbmsUpgradeConfigs(
     await copyDBMSPath(dbms.rootPath, upgradedDbms.rootPath, NEO4J_LOGS_DIR);
     await copyDBMSPath(dbms.rootPath, upgradedDbms.rootPath, NEO4J_CONF_DIR);
     await copyDBMSPath(dbms.rootPath, upgradedDbms.rootPath, NEO4J_PLUGIN_DIR);
+    await copyDBMSPath(dbms.rootPath, upgradedDbms.rootPath, NEO4J_IMPORT_DIR);
 
     const certsExists = await fse.pathExists(path.join(dbms.rootPath, NEO4J_CERT_DIR));
 

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -5630,6 +5630,11 @@
 				}
 			}
 		},
+		"graphql-type-json": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
+			"integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
+		},
 		"graphql-upload": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -65,6 +65,7 @@
         "fs-extra": "9.0.1",
         "graphql": "15.3.0",
         "graphql-tools": "5.0.0",
+        "graphql-type-json": "0.3.2",
         "lodash": "4.17.19",
         "node-fetch": "2.6.1",
         "reflect-metadata": "0.1.13",

--- a/packages/web/src/entities/dbms/dbms.e2e.ts
+++ b/packages/web/src/entities/dbms/dbms.e2e.ts
@@ -206,6 +206,143 @@ describe('DBMSModule', () => {
                     });
                 });
         });
+
+        test('/graphql addDbmsTags', () => {
+            return request(app.getHttpServer())
+                .post('/graphql')
+                .send(
+                    queryBody(
+                        `
+                mutation dbmsTags($environmentNameOrId: String, $dbmsName: String!, $tags: [String!]!) {
+                    addDbmsTags(environmentNameOrId: $environmentNameOrId, dbmsId: $dbmsName, tags: $tags) {
+                        name
+                        tags
+                    }
+                }
+            `,
+                        {tags: ['tag1', 'tag2']},
+                    ),
+                )
+                .expect(HTTP_OK)
+                .expect((res: request.Response) => {
+                    const {addDbmsTags} = res.body.data;
+                    const expected = {
+                        name: TEST_DBMS_NAME,
+                        tags: ['tag1', 'tag2'],
+                    };
+
+                    expect(addDbmsTags).toEqual(expected);
+                });
+        });
+
+        test('/graphql removeDbmsTags', () => {
+            return request(app.getHttpServer())
+                .post('/graphql')
+                .send(
+                    queryBody(
+                        `
+                    mutation dbmsTags($environmentNameOrId: String, $dbmsName: String!, $tags: [String!]!) {
+                        removeDbmsTags(environmentNameOrId: $environmentNameOrId, dbmsId: $dbmsName, tags: $tags) {
+                            name
+                            tags
+                        }
+                    }
+                `,
+                        {tags: ['tag1', 'tag2']},
+                    ),
+                )
+                .expect(HTTP_OK)
+                .expect((res: request.Response) => {
+                    const {removeDbmsTags} = res.body.data;
+                    const expected = {
+                        name: TEST_DBMS_NAME,
+                        tags: [],
+                    };
+
+                    expect(removeDbmsTags).toEqual(expected);
+                });
+        });
+
+        test('/graphql setDbmsMetadata', () => {
+            return request(app.getHttpServer())
+                .post('/graphql')
+                .send(
+                    queryBody(
+                        `
+                        mutation dbmsMetadata(
+                            $environmentNameOrId: String,
+                            $dbmsName: String!,
+                            $key: String!,
+                            $value: JSON!
+                        ) {
+                            setDbmsMetadata(
+                                environmentNameOrId: $environmentNameOrId,
+                                dbmsId: $dbmsName,
+                                key: $key,
+                                value: $value,
+                            ) {
+                                name
+                                metadata
+                            }
+                        }
+                    `,
+                        {
+                            key: 'someKey',
+                            value: {
+                                value1: 'someValue',
+                                value2: {
+                                    foo: 10,
+                                },
+                            },
+                        },
+                    ),
+                )
+                .expect(HTTP_OK)
+                .expect((res: request.Response) => {
+                    const {setDbmsMetadata} = res.body.data;
+                    const expected = {
+                        name: TEST_DBMS_NAME,
+                        metadata: {
+                            someKey: {
+                                value1: 'someValue',
+                                value2: {
+                                    foo: 10,
+                                },
+                            },
+                        },
+                    };
+
+                    expect(setDbmsMetadata).toEqual(expected);
+                });
+        });
+
+        test('/graphql removeDbmsMetadata', () => {
+            return request(app.getHttpServer())
+                .post('/graphql')
+                .send(
+                    queryBody(
+                        `
+                    mutation dbmsMetadata($environmentNameOrId: String, $dbmsName: String!, $keys: [String!]!) {
+                        removeDbmsMetadata(environmentNameOrId: $environmentNameOrId, dbmsId: $dbmsName, keys: $keys) {
+                            name
+                            metadata
+                        }
+                    }
+                `,
+                        {keys: ['someKey']},
+                    ),
+                )
+                .expect(HTTP_OK)
+                .expect((res: request.Response) => {
+                    const {removeDbmsMetadata} = res.body.data;
+                    const expected = {
+                        name: TEST_DBMS_NAME,
+                        metadata: {},
+                    };
+
+                    expect(removeDbmsMetadata).toEqual(expected);
+                });
+        });
     });
 
     describe('dbms started', () => {

--- a/packages/web/src/entities/dbms/dbms.resolver.ts
+++ b/packages/web/src/entities/dbms/dbms.resolver.ts
@@ -16,6 +16,8 @@ import {
     ListDbmsVersionsArgs,
     AddDbmsTagsArgs,
     RemoveDbmsTagsArgs,
+    AddDbmsMetadataArgs,
+    RemoveDbmsMetadataArgs,
 } from './dbms.types';
 import {EnvironmentGuard} from '../../guards/environment.guard';
 import {EnvironmentInterceptor} from '../../interceptors/environment.interceptor';
@@ -124,5 +126,21 @@ export class DBMSResolver {
         @Args() {dbmsId, tags}: RemoveDbmsTagsArgs,
     ): Promise<IDbmsInfo> {
         return environment.dbmss.manifest.removeTags(dbmsId, tags);
+    }
+
+    @Mutation(() => DbmsInfo)
+    async [PUBLIC_GRAPHQL_METHODS.SET_DBMS_METADATA](
+        @Context('environment') environment: Environment,
+        @Args() {dbmsId, key, value}: AddDbmsMetadataArgs,
+    ): Promise<IDbmsInfo> {
+        return environment.dbmss.manifest.setMetadata(dbmsId, key, value);
+    }
+
+    @Mutation(() => DbmsInfo)
+    async [PUBLIC_GRAPHQL_METHODS.REMOVE_DBMS_METADATA](
+        @Context('environment') environment: Environment,
+        @Args() {dbmsId, keys}: RemoveDbmsMetadataArgs,
+    ): Promise<IDbmsInfo> {
+        return environment.dbmss.manifest.removeMetadata(dbmsId, ...keys);
     }
 }

--- a/packages/web/src/entities/dbms/dbms.types.ts
+++ b/packages/web/src/entities/dbms/dbms.types.ts
@@ -1,25 +1,29 @@
 import {ObjectType, ArgsType, Field, ID} from '@nestjs/graphql';
-import {NEO4J_EDITION} from '@relate/common';
+import {IDbms, NEO4J_EDITION} from '@relate/common';
+import GraphQLJSON, {GraphQLJSONObject} from 'graphql-type-json';
 
 import {AuthTokenInput} from './dto/auth-token.input';
 import {EnvironmentArgs} from '../../global.types';
 
 @ObjectType()
-export class Dbms {
+export class Dbms implements Omit<IDbms, 'config'> {
     @Field(() => ID)
     id: string;
 
-    @Field(() => String, {nullable: true})
-    name?: string;
+    @Field(() => String)
+    name: string;
 
-    @Field(() => String, {nullable: true})
-    description?: string;
+    @Field(() => String)
+    description: string;
 
     @Field(() => [String])
     tags: string[];
 
-    @Field(() => String, {nullable: true})
-    connectionUri?: string;
+    @Field(() => GraphQLJSONObject)
+    metadata: Record<string, any>;
+
+    @Field(() => String)
+    connectionUri: string;
 }
 
 @ObjectType()
@@ -113,6 +117,27 @@ export class RemoveDbmsTagsArgs extends EnvironmentArgs {
 
     @Field(() => [String])
     tags: string[];
+}
+
+@ArgsType()
+export class AddDbmsMetadataArgs extends EnvironmentArgs {
+    @Field(() => String)
+    dbmsId: string;
+
+    @Field(() => String)
+    key: string;
+
+    @Field(() => GraphQLJSON)
+    value: any;
+}
+
+@ArgsType()
+export class RemoveDbmsMetadataArgs extends EnvironmentArgs {
+    @Field(() => String)
+    dbmsId: string;
+
+    @Field(() => [String])
+    keys: string[];
 }
 
 @ObjectType()

--- a/packages/web/src/entities/project/project.e2e.ts
+++ b/packages/web/src/entities/project/project.e2e.ts
@@ -572,4 +572,146 @@ describe('AppsModule', () => {
                 expect(getProject).toEqual(expected);
             });
     });
+
+    test('/graphql addProjectTags', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `
+                mutation projectTags($environmentNameOrId: String, $name: String!, $tags: [String!]!) {
+                    addProjectTags(environmentNameOrId: $environmentNameOrId, name: $name, tags: $tags) {
+                        name
+                        tags
+                    }
+                }
+            `,
+                    {
+                        name: TEST_PROJECT_NAME,
+                        tags: ['tag1', 'tag2'],
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {addProjectTags} = res.body.data;
+                const expected = {
+                    name: TEST_PROJECT_NAME,
+                    tags: ['tag1', 'tag2'],
+                };
+
+                expect(addProjectTags).toEqual(expected);
+            });
+    });
+
+    test('/graphql removeProjectTags', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `
+                    mutation projectTags($environmentNameOrId: String, $name: String!, $tags: [String!]!) {
+                        removeProjectTags(environmentNameOrId: $environmentNameOrId, name: $name, tags: $tags) {
+                            name
+                            tags
+                        }
+                    }
+                `,
+                    {
+                        name: TEST_PROJECT_NAME,
+                        tags: ['tag1', 'tag2'],
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {removeProjectTags} = res.body.data;
+                const expected = {
+                    name: TEST_PROJECT_NAME,
+                    tags: [],
+                };
+
+                expect(removeProjectTags).toEqual(expected);
+            });
+    });
+
+    test('/graphql setProjectMetadata', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `
+                        mutation projectMetadata($environmentNameOrId: String, $name: String!, $key: String!, $value: JSON!) {
+                            setProjectMetadata(
+                                environmentNameOrId: $environmentNameOrId,
+                                name: $name,
+                                key: $key,
+                                value: $value,
+                            ) {
+                                name
+                                metadata
+                            }
+                        }
+                    `,
+                    {
+                        name: TEST_PROJECT_NAME,
+                        key: 'someKey',
+                        value: {
+                            value1: 'someValue',
+                            value2: {
+                                foo: 10,
+                            },
+                        },
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {setProjectMetadata} = res.body.data;
+                const expected = {
+                    name: TEST_PROJECT_NAME,
+                    metadata: {
+                        someKey: {
+                            value1: 'someValue',
+                            value2: {
+                                foo: 10,
+                            },
+                        },
+                    },
+                };
+
+                expect(setProjectMetadata).toEqual(expected);
+            });
+    });
+
+    test('/graphql removeProjectMetadata', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `
+                    mutation projectMetadata($environmentNameOrId: String, $name: String!, $keys: [String!]!) {
+                        removeProjectMetadata(environmentNameOrId: $environmentNameOrId, name: $name, keys: $keys) {
+                            name
+                            metadata
+                        }
+                    }
+                `,
+                    {
+                        name: TEST_PROJECT_NAME,
+                        keys: ['someKey'],
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {removeProjectMetadata} = res.body.data;
+                const expected = {
+                    name: TEST_PROJECT_NAME,
+                    metadata: {},
+                };
+
+                expect(removeProjectMetadata).toEqual(expected);
+            });
+    });
 });

--- a/packages/web/src/entities/project/project.resolver.ts
+++ b/packages/web/src/entities/project/project.resolver.ts
@@ -6,12 +6,16 @@ import {List} from '@relate/types';
 import {
     AddProjectDbmsArgs,
     AddProjectFileArgs,
+    AddProjectMetadataArgs,
+    AddProjectTagsArgs,
     InitProjectArgs,
     Project,
     ProjectArgs,
     ProjectDbms,
     RemoveProjectDbmsArgs,
     RemoveProjectFileArgs,
+    RemoveProjectMetadataArgs,
+    RemoveProjectTagsArgs,
 } from './project.types';
 import {EnvironmentArgs, FilterArgs, RelateFile} from '../../global.types';
 import {EnvironmentGuard} from '../../guards/environment.guard';
@@ -119,5 +123,57 @@ export class ProjectResolver {
         @Args() {name, filePath}: RemoveProjectFileArgs,
     ): Promise<RelateFile> {
         return environment.projects.removeFile(name, filePath);
+    }
+
+    @Mutation(() => Project)
+    async [PUBLIC_GRAPHQL_METHODS.ADD_PROJECT_TAGS](
+        @Context('environment') environment: Environment,
+        @Args() {name, tags}: AddProjectTagsArgs,
+    ): Promise<Project> {
+        const project = await environment.projects.manifest.addTags(name, tags);
+
+        return {
+            ...project,
+            files: [],
+        };
+    }
+
+    @Mutation(() => Project)
+    async [PUBLIC_GRAPHQL_METHODS.REMOVE_PROJECT_TAGS](
+        @Context('environment') environment: Environment,
+        @Args() {name, tags}: RemoveProjectTagsArgs,
+    ): Promise<Project> {
+        const project = await environment.projects.manifest.removeTags(name, tags);
+
+        return {
+            ...project,
+            files: [],
+        };
+    }
+
+    @Mutation(() => Project)
+    async [PUBLIC_GRAPHQL_METHODS.SET_PROJECT_METADATA](
+        @Context('environment') environment: Environment,
+        @Args() {name, key, value}: AddProjectMetadataArgs,
+    ): Promise<Project> {
+        const project = await environment.projects.manifest.setMetadata(name, key, value);
+
+        return {
+            ...project,
+            files: [],
+        };
+    }
+
+    @Mutation(() => Project)
+    async [PUBLIC_GRAPHQL_METHODS.REMOVE_PROJECT_METADATA](
+        @Context('environment') environment: Environment,
+        @Args() {name, keys}: RemoveProjectMetadataArgs,
+    ): Promise<Project> {
+        const project = await environment.projects.manifest.removeMetadata(name, ...keys);
+
+        return {
+            ...project,
+            files: [],
+        };
     }
 }

--- a/packages/web/src/entities/project/project.types.ts
+++ b/packages/web/src/entities/project/project.types.ts
@@ -1,11 +1,12 @@
 import {ObjectType, ArgsType, Field} from '@nestjs/graphql';
 import {IProject, IProjectDbms} from '@relate/common';
-import {IFileUpload, GraphQLUpload} from './graphql-upload';
+import GraphQLJSON, {GraphQLJSONObject} from 'graphql-type-json';
 
+import {IFileUpload, GraphQLUpload} from './graphql-upload';
 import {EnvironmentArgs, RelateFile} from '../../global.types';
 
 @ObjectType()
-export class Project implements Omit<IProject, 'root' | 'metadata'> {
+export class Project implements Omit<IProject, 'root'> {
     @Field(() => String)
     id: string;
 
@@ -17,6 +18,9 @@ export class Project implements Omit<IProject, 'root' | 'metadata'> {
 
     @Field(() => [String])
     tags: string[];
+
+    @Field(() => GraphQLJSONObject)
+    metadata: Record<string, any>;
 
     @Field(() => [ProjectDbms])
     dbmss: ProjectDbms[];
@@ -89,4 +93,31 @@ export class AddProjectFileArgs extends ProjectArgs {
 export class RemoveProjectFileArgs extends ProjectArgs {
     @Field(() => String)
     filePath: string;
+}
+
+@ArgsType()
+export class AddProjectTagsArgs extends ProjectArgs {
+    @Field(() => [String])
+    tags: string[];
+}
+
+@ArgsType()
+export class RemoveProjectTagsArgs extends ProjectArgs {
+    @Field(() => [String])
+    tags: string[];
+}
+
+@ArgsType()
+export class AddProjectMetadataArgs extends ProjectArgs {
+    @Field(() => String)
+    key: string;
+
+    @Field(() => GraphQLJSON)
+    value: any;
+}
+
+@ArgsType()
+export class RemoveProjectMetadataArgs extends ProjectArgs {
+    @Field(() => [String])
+    keys: string[];
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Feature


### What is the current behavior?
- No way to set/remove metadata on DBMSs and projects.
- No way to add/remove tags on projects.
- No way to read existing metadata from DBMSs and projects.
- The import directory is not copied into new DBMSs during upgrades.

### What is the new behavior?
New mutations are available to:
- Set/remove metadata on DBMSs and projects
- Add/remove tags on projects

The `metadata` field is available on both DBMSs and projects.
The import directory is copied into new DBMSs during upgrades.

### Does this PR introduce a breaking change?
No


### Other information: