### PR TITLE
Install sample projects

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,6 +9,7 @@ CLI tool for interacting with the Neo4j platform.
 
 - [@relate/cli](#relatecli)
 - [Usage](#usage)
+- [Development](#development)
 - [Commands](#commands)
 - [Command Topics](#command-topics)
 

--- a/packages/cli/docs/project.md
+++ b/packages/cli/docs/project.md
@@ -6,6 +6,7 @@ Projects bring files and data together.
 * [`relate project:add-dbms DBMS`](#relate-projectadd-dbms-dbms)
 * [`relate project:add-file SOURCE`](#relate-projectadd-file-source)
 * [`relate project:init`](#relate-projectinit)
+* [`relate project:install-sample`](#relate-projectinstall-sample)
 * [`relate project:link FILEPATH`](#relate-projectlink-filepath)
 * [`relate project:list`](#relate-projectlist)
 * [`relate project:list-dbmss`](#relate-projectlist-dbmss)
@@ -85,6 +86,25 @@ EXAMPLES
 ```
 
 _See code: [dist/commands/project/init.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.17/packages/cli/src/commands/project/init.ts)_
+
+## `relate project:install-sample`
+
+Install sample project
+
+```
+USAGE
+  $ relate project:install-sample
+
+OPTIONS
+  -e, --environment=environment  Name of the environment to run the command against
+  -p, --project=project          (required) Name of the project to run the command against
+  -t, --to=to                    Path where the project directory will be created.
+
+EXAMPLE
+  $ relate project:install-sample
+```
+
+_See code: [dist/commands/project/install-sample.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.17/packages/cli/src/commands/project/install-sample.ts)_
 
 ## `relate project:link FILEPATH`
 

--- a/packages/cli/src/commands/project/install-sample.ts
+++ b/packages/cli/src/commands/project/install-sample.ts
@@ -1,0 +1,25 @@
+import {flags} from '@oclif/command';
+
+import BaseCommand from '../../base.command';
+
+import {FLAGS} from '../../constants';
+import {InstallSampleModule} from '../../modules/project/install-sample.module';
+
+export default class InstallSampleCommand extends BaseCommand {
+    commandClass = InstallSampleCommand;
+
+    commandModule = InstallSampleModule;
+
+    static description = 'Install sample project';
+
+    static examples = ['$ relate project:install-sample'];
+
+    static flags = {
+        ...FLAGS.ENVIRONMENT,
+        ...FLAGS.PROJECT,
+        to: flags.string({
+            char: 't',
+            description: 'Path where the project directory will be created.',
+        }),
+    };
+}

--- a/packages/cli/src/modules/db/load.module.ts
+++ b/packages/cli/src/modules/db/load.module.ts
@@ -25,13 +25,14 @@ export class LoadModule implements OnApplicationBootstrap {
         const {flags} = this.parsed;
         const {from, database, force} = flags;
 
+        const filePath = path.resolve(from);
+
         try {
-            await fse.ensureFile(from);
+            await fse.ensureFile(filePath);
         } catch (e) {
-            throw new NotFoundError(`File not found (${from})`);
+            throw new NotFoundError(`File not found (${filePath})`);
         }
 
-        const filePath = path.resolve(from);
         const environment = await this.systemProvider.getEnvironment(flags.environment);
 
         let {dbms: dbmsId} = this.parsed.args;

--- a/packages/cli/src/modules/project/install-sample.module.ts
+++ b/packages/cli/src/modules/project/install-sample.module.ts
@@ -1,0 +1,100 @@
+import {OnApplicationBootstrap, Module, Inject} from '@nestjs/common';
+import {SystemModule, SystemProvider} from '@relate/common';
+import chalk from 'chalk';
+import cli from 'cli-ux';
+import path from 'path';
+
+import InstallSampleCommand from '../../commands/project/install-sample';
+import {passwordPrompt, selectPrompt, confirmPrompt} from '../../prompts';
+
+@Module({
+    exports: [],
+    imports: [SystemModule],
+    providers: [],
+})
+export class InstallSampleModule implements OnApplicationBootstrap {
+    constructor(
+        @Inject('PARSED_PROVIDER') protected readonly parsed: ParsedInput<typeof InstallSampleCommand>,
+        @Inject('UTILS_PROVIDER') protected readonly utils: CommandUtils,
+        @Inject(SystemProvider) protected readonly systemProvider: SystemProvider,
+    ) {}
+
+    async onApplicationBootstrap(): Promise<void> {
+        const {flags} = this.parsed;
+        const {to} = flags;
+
+        let destPath;
+        if (to) {
+            destPath = path.resolve(to);
+        }
+
+        const {environment: environmentId} = flags;
+        const environment = await this.systemProvider.getEnvironment(environmentId);
+        const sampleProjects = await environment.projects.listSampleProjects();
+
+        cli.table(
+            sampleProjects.toArray(),
+            {
+                name: {},
+                description: {},
+            },
+            {
+                printLine: this.utils.log,
+                ...flags,
+            },
+        );
+
+        this.utils.log(' ');
+
+        const selected = await selectPrompt(
+            'Select a sample project to install',
+            sampleProjects.toArray().map((item: {name: string}) => ({
+                message: item.name,
+                name: item.name,
+            })),
+        );
+
+        cli.action.start(`Downloading '${selected}'.`);
+        const {path: downloadPath, temp} = await environment.projects.downloadSampleProject(selected, destPath);
+        cli.action.stop(chalk.green('done'));
+
+        cli.action.start(`Creating project '${selected}'.`);
+        const manifests = await environment.projects.installSampleProject(downloadPath, {
+            name: selected,
+            temp,
+        });
+        cli.action.stop(chalk.green('done'));
+
+        if (manifests?.install?.dbms) {
+            for (const dbms of manifests.install.dbms) {
+                dbms.name = dbms.name || manifests.install.name;
+
+                this.utils.log(' ');
+                this.utils.log(
+                    chalk.cyan(`We found install instructions for '${dbms.name}, ${dbms.targetNeo4jVersion}'.`),
+                );
+
+                /* eslint-disable no-await-in-loop */
+                const selection = await confirmPrompt('Do you want to install this?');
+                if (selection) {
+                    this.utils.log(' ');
+                    /* eslint-disable no-await-in-loop */
+                    const credentials = await passwordPrompt('Enter new passphrase');
+
+                    cli.action.start(`Creating '${dbms.name}' DBMS and importing data`);
+                    /* eslint-disable no-await-in-loop */
+                    const {created} = await environment.projects.importSampleDbms(
+                        manifests.project.id,
+                        dbms,
+                        credentials,
+                    );
+                    cli.action.stop(chalk.green('done'));
+
+                    if (created) {
+                        this.utils.log(chalk.green(`Successfully created ${created.name}.`));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -5,6 +5,7 @@ import {IRelateBackup} from './models';
 export enum ENTITY_TYPES {
     DBMS = 'dbms',
     PROJECT = 'project',
+    PROJECT_INSTALL = 'project-install',
     DB = 'db',
     EXTENSION = 'extension',
     ENVIRONMENT = 'environment',
@@ -19,6 +20,7 @@ export const DOWNLOADING_FILE_EXTENSION = '.rdownload';
 export const BACKUP_MANIFEST_FILE = `relate.${ENTITY_TYPES.BACKUP}.json`;
 export const DBMS_MANIFEST_FILE = `relate.${ENTITY_TYPES.DBMS}.json`;
 export const PROJECT_MANIFEST_FILE = `relate.${ENTITY_TYPES.PROJECT}.json`;
+export const PROJECT_INSTALL_MANIFEST_FILE = `relate.${ENTITY_TYPES.PROJECT_INSTALL}.json`;
 export const EXTENSION_MANIFEST_FILE = `relate.${ENTITY_TYPES.EXTENSION}.json`;
 
 export const RELATE_ACCESS_TOKENS_DIR_NAME = 'access-tokens';
@@ -165,6 +167,9 @@ export enum PUBLIC_GRAPHQL_METHODS {
     REMOVE_PROJECT_TAGS = 'removeProjectTags',
     SET_PROJECT_METADATA = 'setProjectMetadata',
     REMOVE_PROJECT_METADATA = 'removeProjectMetadata',
+    LIST_SAMPLES_PROJECTS = 'listSampleProjects',
+    INSTALL_SAMPLE_PROJECTS = 'installSampleProjects',
+    IMPORT_SAMPLE_DBMS = 'importSampleDbms',
 
     // dump / import
     DB_DUMP = 'dbDump',

--- a/packages/common/src/entities/environments/environment.local.ts
+++ b/packages/common/src/entities/environments/environment.local.ts
@@ -56,6 +56,9 @@ export class LocalEnvironment extends EnvironmentAbstract {
             case ENTITY_TYPES.PROJECT:
                 return path.join(this.dirPaths.projectsData, `${ENTITY_TYPES.PROJECT}-${id}`);
 
+            case ENTITY_TYPES.PROJECT_INSTALL:
+                return path.join(this.dirPaths.projectsData, `${ENTITY_TYPES.PROJECT}-${id}`);
+
             case ENTITY_TYPES.EXTENSION:
                 return path.join(this.dirPaths.extensionsData, `${ENTITY_TYPES.EXTENSION}-${id}`);
 

--- a/packages/common/src/entities/projects/projects.abstract.ts
+++ b/packages/common/src/entities/projects/projects.abstract.ts
@@ -1,8 +1,20 @@
 import {List} from '@relate/types';
+import {Got} from 'got';
 
 import {EnvironmentAbstract} from '../environments';
 import {ManifestAbstract} from '../manifest';
-import {IRelateFile, IProject, IProjectDbms, WriteFileFlag, ProjectManifestModel, IProjectInput} from '../../models';
+import {
+    IRelateFile,
+    IProject,
+    IProjectDbms,
+    WriteFileFlag,
+    ProjectManifestModel,
+    IProjectInput,
+    IDbmsInfo,
+    ISampleProjectDbms,
+    ISampleProjectInput,
+    ISampleProjectRest,
+} from '../../models';
 import {IRelateFilter} from '../../utils/generic';
 
 export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
@@ -114,4 +126,35 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
      * @param   dbmsName
      */
     abstract removeDbms(nameOrId: string, dbmsName: string): Promise<IProjectDbms>;
+
+    /**
+     * Lists sample projects from github (https://github.com/neo4j-graph-examples)
+     */
+    abstract listSampleProjects(fetch?: () => any | Got): Promise<List<ISampleProjectRest>>;
+
+    /**
+     * Download sample project from github (https://github.com/neo4j-graph-examples)
+     */
+    abstract downloadSampleProject(selected: string, destPath?: string): Promise<{path: string; temp: boolean}>;
+
+    /**
+     * Install sample project from file
+     */
+    abstract installSampleProject(
+        srcPath: string,
+        args: {
+            name?: string;
+            projectId?: string;
+            temp?: boolean;
+        },
+    ): Promise<{project: IProjectInput; install?: ISampleProjectInput}>;
+
+    /**
+     * Install sample DBMSs from file
+     */
+    abstract importSampleDbms(
+        projectId: string,
+        dbms: ISampleProjectDbms,
+        credentials: string,
+    ): Promise<{created: IDbmsInfo; dump?: string; script?: string}>;
 }

--- a/packages/common/src/entities/projects/projects.local.test.ts
+++ b/packages/common/src/entities/projects/projects.local.test.ts
@@ -213,4 +213,15 @@ describe('LocalProjects', () => {
             directory: testProjectDir,
         });
     });
+
+    test('projects.listSampleProjects()', async () => {
+        const result = (await environment.projects.listSampleProjects()).toArray();
+        const [first] = result;
+
+        // This test ensures that the structure of the response from GitHub is correct
+        // @TODO: Handle cases where GitHub might be unreachable?
+
+        expect(result.length).toBeGreaterThan(0);
+        expect(Object.keys(first)).toEqual(expect.arrayContaining(['name', 'description', 'downloadUrl']));
+    });
 });

--- a/packages/common/src/entities/projects/projects.remote.ts
+++ b/packages/common/src/entities/projects/projects.remote.ts
@@ -1,6 +1,17 @@
 import {List} from '@relate/types';
+import {Got} from 'got';
 
-import {IRelateFile, IProject, IProjectDbms, ProjectManifestModel, IProjectInput} from '../../models';
+import {
+    IRelateFile,
+    IProject,
+    IProjectDbms,
+    ProjectManifestModel,
+    IProjectInput,
+    ISampleProjectRest,
+    IDbmsInfo,
+    ISampleProjectDbms,
+    ISampleProjectInput,
+} from '../../models';
 import {ProjectsAbstract} from './projects.abstract';
 import {RemoteEnvironment} from '../environments';
 import {NotSupportedError} from '../../errors';
@@ -68,5 +79,32 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
 
     removeDbms(_nameOrId: string, _dbmsName: string): Promise<IProjectDbms> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support removing project dbms`);
+    }
+
+    listSampleProjects(_fetch?: () => any | Got): Promise<List<ISampleProjectRest>> {
+        throw new NotSupportedError(`${RemoteProjects.name} does not support listing sample projects`);
+    }
+
+    downloadSampleProject(_selected: string, _destPath?: string): Promise<{path: string; temp: boolean}> {
+        throw new NotSupportedError(`${RemoteProjects.name} does not support downloading sample projects`);
+    }
+
+    installSampleProject(
+        _srcPath: string,
+        _args: {
+            name?: string;
+            projectId?: string;
+            temp?: boolean;
+        },
+    ): Promise<{project: IProjectInput; install?: ISampleProjectInput}> {
+        throw new NotSupportedError(`${RemoteProjects.name} does not support installing sample projects`);
+    }
+
+    importSampleDbms(
+        _projectId: string,
+        _dbms: ISampleProjectDbms,
+        _credentials: string,
+    ): Promise<{created: IDbmsInfo; dump?: string; script?: string}> {
+        throw new NotSupportedError(`${RemoteProjects.name} does not support installing sample dbmss`);
     }
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -2,6 +2,7 @@ export {IAuthToken} from '@huboneo/tapestry';
 // @todo: better way of handling types
 export {IExtensionVersion, loadExtensionsFor, getAppLaunchUrl} from './utils/extensions';
 export {TestDbmss, TestExtensions, TestEnvironment} from './utils/system';
+export {GraphQLClient, GraphQLAbstract} from './utils/graphql';
 export * from './system';
 export * from './models';
 export * from './errors';

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -11,5 +11,6 @@ export * from './extension.model';
 export * from './authentication.model';
 export * from './file.model';
 export * from './project.model';
+export * from './project-install.model';
 export * from './relate-backup.model';
 export * from './manifest.model';

--- a/packages/common/src/models/project-install.model.ts
+++ b/packages/common/src/models/project-install.model.ts
@@ -1,0 +1,46 @@
+import {IsArray, IsOptional} from 'class-validator';
+import {assign} from 'lodash';
+import {ManifestModel, IManifest, IManifestInput} from './manifest.model';
+
+export interface ISampleProjectInput extends IManifestInput {
+    name: string;
+    description: string;
+    dbms: ISampleProjectDbms[];
+}
+export interface ISampleProjectManifest extends IManifest {
+    name: string;
+    description: string;
+    dbms: ISampleProjectDbms[];
+}
+
+export interface ISampleProject extends IManifest {
+    name: string;
+    description: string;
+}
+
+export interface ISampleProjectDbms {
+    name?: string;
+    description?: string;
+    dumpFile?: string;
+    scriptFile?: string;
+    targetNeo4jVersion: string;
+}
+
+export interface ISampleProjectRest {
+    name: string;
+    description: string;
+    downloadUrl: string;
+}
+
+export class ProjectInstallManifestModel extends ManifestModel<ISampleProject> implements ISampleProjectManifest {
+    constructor(props: any) {
+        super(props);
+
+        // reassigning default values doesn't work when it's done from the parent class
+        assign(this, props);
+    }
+
+    @IsOptional()
+    @IsArray()
+    public dbms: ISampleProjectDbms[] = [];
+}

--- a/packages/common/src/utils/graphql.ts
+++ b/packages/common/src/utils/graphql.ts
@@ -1,0 +1,70 @@
+import {ApolloLink, execute, FetchResult, GraphQLRequest, makePromise} from 'apollo-link';
+import {createHttpLink} from 'apollo-link-http';
+import fetch from 'node-fetch';
+
+import {Dict} from '@relate/types';
+
+import {NotAllowedError} from '../errors';
+
+export abstract class GraphQLAbstract {
+    /**
+     * @hidden
+     */
+    constructor(protected readonly config: IGraphQLConfig) {}
+
+    /**
+     * Executes an operation
+     * @operation   operation
+     */
+    abstract execute(operation: GraphQLRequest): Promise<FetchResult<{[key: string]: any}>>;
+}
+
+export interface IGraphQLConfig {
+    uri: string;
+    headers: {[key: string]: any};
+}
+
+export class GraphQLClient extends GraphQLAbstract {
+    private client: ApolloLink;
+
+    constructor(protected readonly config: IGraphQLConfig) {
+        super(config);
+        const {uri, headers} = config;
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        this.client = createHttpLink({
+            // HttpLink wants a fetch implementation to make requests to a
+            // GraphQL API. It wants the browser version of it which has a
+            // few more options than the node version.
+            credentials: 'include',
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
+            fetch: (url: string, opts: any) => {
+                // @todo: this could definitely be done better
+                const options = Dict.from(opts)
+                    .merge({
+                        credentials: 'include',
+                        headers,
+                        mode: 'cors',
+                    })
+                    .toObject();
+
+                return fetch(url, options);
+            },
+            uri,
+        });
+    }
+
+    public async execute(operation: GraphQLRequest): Promise<FetchResult<{[key: string]: any}>> {
+        try {
+            const res = await makePromise(execute(this.client, operation));
+            return res;
+        } catch (err) {
+            if (err.statusCode === 401 || err.statusCode === 403) {
+                throw new NotAllowedError('Unauthorized: must login to perform this operation');
+            }
+            throw err;
+        }
+    }
+}

--- a/packages/common/src/utils/system/get-manifest-name.ts
+++ b/packages/common/src/utils/system/get-manifest-name.ts
@@ -1,4 +1,10 @@
-import {DBMS_MANIFEST_FILE, ENTITY_TYPES, EXTENSION_MANIFEST_FILE, PROJECT_MANIFEST_FILE} from '../../constants';
+import {
+    DBMS_MANIFEST_FILE,
+    ENTITY_TYPES,
+    EXTENSION_MANIFEST_FILE,
+    PROJECT_INSTALL_MANIFEST_FILE,
+    PROJECT_MANIFEST_FILE,
+} from '../../constants';
 import {InvalidArgumentError} from '../../errors';
 
 export function getManifestName(entityType: ENTITY_TYPES): string {
@@ -8,6 +14,9 @@ export function getManifestName(entityType: ENTITY_TYPES): string {
 
         case ENTITY_TYPES.PROJECT:
             return PROJECT_MANIFEST_FILE;
+
+        case ENTITY_TYPES.PROJECT_INSTALL:
+            return PROJECT_INSTALL_MANIFEST_FILE;
 
         case ENTITY_TYPES.EXTENSION:
             return EXTENSION_MANIFEST_FILE;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
It introduces a new command `relate project:install-sample`, which grabs a list of Sample Projects from https://github.com/neo4j-graph-examples that are marked as `neo4j-approved` or some other filter that we decide on.
These projects contains sample data and also a new file (`relate.project-install.json`) that describes how Relate/Desktop should install Sample DBMSs and import sample data. See https://github.com/neo4j-graph-examples/northwind for an example.
The user will be prompted to install any DBMSs found under the dbms section in the file.

Note!

Currently the file is named `relate.project.json` in the northwind example. Because of this the second step doesn't work when testing the command.

### What is the current behavior?
(You can also link to an open issue here)


### What is the new behavior?
(if this is a feature change)


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)


### Other information:
