### PR TITLE
Reduce manifest reads

### DIFF
--- a/packages/common/src/entities/dbmss/dbmss.local.ts
+++ b/packages/common/src/entities/dbmss/dbmss.local.ts
@@ -329,13 +329,8 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
         }
 
         // Enforce unique names
-        const dbmsNameExists = await this.list([
-            {
-                field: 'name',
-                value: manifestModel.name,
-            },
-        ]);
-        if (!dbmsNameExists.isEmpty) {
+        const dbmsNameExists = await this.getDbms(manifestModel.name).catch(() => null);
+        if (dbmsNameExists) {
             throw new InvalidArgumentError(`DBMS "${manifestModel.name}" already exists`, ['Use a unique name']);
         }
 
@@ -376,20 +371,23 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
     }
 
     async uninstall(nameOrId: string): Promise<IDbmsInfo> {
-        const {id} = resolveDbms(this.dbmss, nameOrId);
+        const {id} = await this.getDbms(nameOrId);
         const status = Str.from(await neo4jCmd(this.getDbmsRootPath(id), 'status'));
 
         if (status.includes(DBMS_STATUS_FILTERS.STARTED)) {
             throw new NotAllowedError('Cannot uninstall DBMS that is running');
         }
 
-        return this.uninstallNeo4j(id);
+        const dbms = await this.uninstallNeo4j(id);
+        delete this.dbmss[dbms.id];
+        return dbms;
     }
 
     start(nameOrIds: string[] | List<string>): Promise<List<string>> {
         return List.from(nameOrIds)
-            .mapEach((nameOrId) => resolveDbms(this.dbmss, nameOrId).id)
-            .mapEach((id) => {
+            .mapEach(async (nameOrId) => {
+                const {id} = await this.getDbms(nameOrId);
+
                 if (process.platform === 'win32') {
                     return winNeo4jStart(this.getDbmsRootPath(id));
                 }
@@ -401,8 +399,8 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
 
     stop(nameOrIds: string[] | List<string>): Promise<List<string>> {
         return List.from(nameOrIds)
-            .mapEach((nameOrId) => resolveDbms(this.dbmss, nameOrId).id)
-            .mapEach((id) => {
+            .mapEach(async (nameOrId) => {
+                const {id} = await this.getDbms(nameOrId);
                 if (process.platform === 'win32') {
                     return winNeo4jStop(this.getDbmsRootPath(id));
                 }
@@ -414,8 +412,8 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
 
     info(nameOrIds: string[] | List<string>, onlineCheck?: boolean): Promise<List<IDbmsInfo>> {
         return List.from(nameOrIds)
-            .mapEach((nameOrId) => resolveDbms(this.dbmss, nameOrId))
-            .mapEach(async (dbms) => {
+            .mapEach(async (nameOrId) => {
+                const dbms = await this.getDbms(nameOrId);
                 const v = dbms.rootPath ? await getDistributionInfo(dbms.rootPath) : null;
 
                 let status: DBMS_STATUS;
@@ -457,7 +455,7 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
     }
 
     async updateConfig(nameOrId: string, properties: Map<string, string>): Promise<boolean> {
-        const dbmsId = resolveDbms(this.dbmss, nameOrId).id;
+        const dbmsId = await this.getDbms(nameOrId).then((dbms) => dbms.id);
         const neo4jConfig = await PropertiesFile.readFile(
             path.join(this.getDbmsRootPath(dbmsId), NEO4J_CONF_DIR, NEO4J_CONF_FILE),
         );
@@ -476,17 +474,44 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
         return applyEntityFilters(Dict.from(this.dbmss).values, filters);
     }
 
+    // @todo - Replace dbmss.get with this method for further performance gains.
+    private async getDbms(nameOrId: string): Promise<IDbms> {
+        try {
+            const dbms = resolveDbms(this.dbmss, nameOrId);
+            if (await this.environment.entityExists(ENTITY_TYPES.DBMS, dbms.id)) {
+                return dbms;
+            }
+        } catch {
+            await this.discoverDbmss();
+        }
+
+        try {
+            const dbms = resolveDbms(this.dbmss, nameOrId);
+            if (await this.environment.entityExists(ENTITY_TYPES.DBMS, dbms.id)) {
+                return dbms;
+            }
+
+            throw new NotFoundError(`DBMS "${nameOrId}" not found`);
+        } catch (e) {
+            throw new NotFoundError(`DBMS "${nameOrId}" not found`);
+        }
+    }
+
     async get(nameOrId: string, onlineCheck?: boolean): Promise<IDbmsInfo> {
-        await this.discoverDbmss();
+        try {
+            resolveDbms(this.dbmss, nameOrId);
+        } catch {
+            await this.discoverDbmss();
+        }
 
         try {
             const info = await this.info([nameOrId], onlineCheck);
 
             return info.first.getOrElse(() => {
-                throw new InvalidArgumentError(`DBMS "${nameOrId}" not found`);
+                throw new NotFoundError(`DBMS "${nameOrId}" not found`);
             });
         } catch (e) {
-            throw new InvalidArgumentError(`DBMS "${nameOrId}" not found`);
+            throw new NotFoundError(`DBMS "${nameOrId}" not found`);
         }
     }
 

--- a/packages/common/src/entities/environments/environment.local.ts
+++ b/packages/common/src/entities/environments/environment.local.ts
@@ -82,8 +82,6 @@ export class LocalEnvironment extends EnvironmentAbstract {
     async init(): Promise<void> {
         await ensureDirs(this.dirPaths);
 
-        await this.dbmss.list();
-
         // @todo: this needs to be done proper
         const securityPluginFilename = `${NEO4J_JWT_ADDON_NAME}-${NEO4J_JWT_ADDON_VERSION}.jar`;
         const securityPluginTmp = path.join(__dirname, '..', '..', '..', securityPluginFilename);

--- a/packages/common/src/entities/manifest/manifest.local.ts
+++ b/packages/common/src/entities/manifest/manifest.local.ts
@@ -136,7 +136,10 @@ export class ManifestLocal<Entity extends IManifest, Manifest extends ManifestMo
         const manifest = Dict.from(await this.get(id));
         const updated = merge ? manifest.merge(update).merge({id}) : manifest.assign(update).assign({id});
 
-        await emitHookEvent(HOOK_EVENTS.MANIFEST_WRITE, manifestPath);
+        await emitHookEvent(HOOK_EVENTS.MANIFEST_WRITE, {
+            manifestPath,
+            update,
+        });
         await fse.ensureFile(manifestPath);
         await fse.writeJson(manifestPath, new this.EntityModel(updated.toObject()), {
             encoding: 'utf8',

--- a/packages/common/src/entities/projects/link.test.ts
+++ b/packages/common/src/entities/projects/link.test.ts
@@ -71,7 +71,7 @@ describe('LocalProjects - link', () => {
 
     test('Is not discovered if target is removed or missing', async () => {
         await fse.move(tmpPath, tmpPath2);
-        await expect(environment.projects.get('bar')).rejects.toThrow(new NotFoundError('Could not find project bar'));
+        await expect(environment.projects.get('bar')).rejects.toThrow(new NotFoundError('Project "bar" not found'));
     });
 
     test('Symlink is updated if linking again a project that was moved', async () => {
@@ -88,7 +88,7 @@ describe('LocalProjects - link', () => {
 
         expect(result.name).toEqual('bar');
         expect(targetPathExists).toEqual(true);
-        await expect(environment.projects.get('bar')).rejects.toThrow(new NotFoundError('Could not find project bar'));
+        await expect(environment.projects.get('bar')).rejects.toThrow(new NotFoundError('Project "bar" not found'));
     });
 
     test('Existing manifest is preferred over the given name', async () => {
@@ -104,6 +104,6 @@ describe('LocalProjects - link', () => {
 
         expect(result.name).toEqual(newManifest.name);
         expect(result.tags).toEqual(newManifest.tags);
-        await expect(environment.projects.get('bar')).rejects.toThrow(new NotFoundError('Could not find project bar'));
+        await expect(environment.projects.get('bar')).rejects.toThrow(new NotFoundError('Project "bar" not found'));
     });
 });

--- a/packages/web/src/entities/project/project.e2e.ts
+++ b/packages/web/src/entities/project/project.e2e.ts
@@ -103,7 +103,7 @@ describe('AppsModule', () => {
             .expect(HTTP_OK)
             .expect((res: request.Response) => {
                 const [{message}] = res.body.errors;
-                const expected = `Could not find project ${TEST_PROJECT_NAME}`;
+                const expected = `Project "${TEST_PROJECT_NAME}" not found`;
 
                 expect(message).toEqual(expected);
             });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Performance improvements

### What is the current behavior?
- When initializing an environment, all DBMS manifests in that environment are read.
- When linking a DBMS, all DBMS manifests are read.
- When getting a DBMS, all DBMS manifests are read.
- `resolveProjects` reads all project manifests to retrieve one project.
- No guards against multiple projects having the same name.

### What is the new behavior?
- Initializing an environment doesn't trigger any DBMS reads.
- Linking a DBMS gets a DBMS instead of listing all of them.
- When getting a DBMS, if the DBMS exists in memory, no manifests are read. Otherwise, all DBMS manifests are read.
- `resolveProjects` works as `resolveDbms` without reading any manifest.
- Projects behavior is now consistent with DBMSs in case of duplicate names. 

### Does this PR introduce a breaking change?
No


### Other information:
Further optimizations can be done, especially for projects, but they would require some more refactoring, so leaving that for later, 
considering this should be a good start in reducing the chance of reading and writing to a manifest at the same time.
 
I measured the impact of these changes by running a few CLI commands and using the `MANIFEST_READ` hook to count the number of total reads. And then compared the results between this branch and master. I tested with one environment, 3 projects, and 6 DBMSs. Below are the results:

| Command         | # of reads (master) | # of reads (this PR) |
|-----------------|---------------------|----------------------|
| dbms:info          | 24                  | 6                    |
| dbms:start [id] | 18                  | 6                    |
| dbms:stop [id]  | 18                  | 6                    |
| dbms:start         | 24                  | 6                    |
| dbms:stop         | 24                  | 6                    |
| project:list          | 21                  | 3                    |

Note that the CLI commands are spawning an entire application for each command, so the difference in performance is not as dramatic as it would be in a long-running application (eg. Neo4j Desktop).