### PR TITLE
Fix JWT plugin being added multiple times to DBMSs

### DIFF
--- a/packages/common/src/entities/dbmss/dbmss.local.ts
+++ b/packages/common/src/entities/dbmss/dbmss.local.ts
@@ -658,28 +658,34 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
             .split(',')
             .filter((_) => !_.isEmpty);
 
-        neo4jConfig.set(
-            `dbms.security.authentication_providers`,
-            authenticationProviders
-                .concat([`plugin-com.neo4j.plugin.jwt.auth.JwtAuthPlugin`])
-                .join(',')
-                .get(),
-        );
-        neo4jConfig.set(
-            `dbms.security.authorization_providers`,
-            authorizationProviders
-                .concat([`plugin-com.neo4j.plugin.jwt.auth.JwtAuthPlugin`])
-                .join(',')
-                .get(),
-        );
-        neo4jConfig.set(
-            `dbms.security.procedures.unrestricted`,
-            unrestrictedProcedures
-                .concat([`jwt.security.*`])
-                .join(',')
-                .get(),
-        );
-
+        const securityPluginJavaPath = 'plugin-com.neo4j.plugin.jwt.auth.JwtAuthPlugin';
+        if (!authenticationProviders.includes(Str.from(securityPluginJavaPath))) {
+            neo4jConfig.set(
+                `dbms.security.authentication_providers`,
+                authenticationProviders
+                    .concat([securityPluginJavaPath])
+                    .join(',')
+                    .get(),
+            );
+        }
+        if (!authorizationProviders.includes(Str.from(securityPluginJavaPath))) {
+            neo4jConfig.set(
+                `dbms.security.authorization_providers`,
+                authorizationProviders
+                    .concat([securityPluginJavaPath])
+                    .join(',')
+                    .get(),
+            );
+        }
+        if (!unrestrictedProcedures.includes(Str.from('jwt.security.*'))) {
+            neo4jConfig.set(
+                `dbms.security.procedures.unrestricted`,
+                unrestrictedProcedures
+                    .concat([`jwt.security.*`])
+                    .join(',')
+                    .get(),
+            );
+        }
         await neo4jConfig.flush();
 
         const jwtConfigPath = path.join(this.getDbmsRootPath(dbmsId), NEO4J_CONF_DIR, NEO4J_JWT_CONF_FILE);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix


### What is the current behavior?
When linking (or in some cases upgrading) a DBMS that already contains the JWT plugin and the correct configuration for it, it is added again, making the DBMS unable to start.


### What is the new behavior?
When adding the security plugin, the options that are already properly configured are no longer modified.


### Does this PR introduce a breaking change?
No


### Other information:
