### PR TITLE
Fix dbms plugin sources implementation

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -27,6 +27,7 @@ export const RELATE_ACCESS_TOKENS_DIR_NAME = 'access-tokens';
 export const DBMS_DIR_NAME = 'dbmss';
 export const BACKUPS_DIR_NAME = 'backups';
 export const PLUGIN_SOURCES_DIR_NAME = 'plugin-sources';
+export const DEFAULT_PLUGIN_SOURCES_FILE = 'default-sources.json';
 export const NEW_LINE = '\n';
 export const PROPERTIES_SEPARATOR = '=';
 // @todo: this should be generated when installing relate instance

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -26,7 +26,7 @@ export const EXTENSION_MANIFEST_FILE = `relate.${ENTITY_TYPES.EXTENSION}.json`;
 export const RELATE_ACCESS_TOKENS_DIR_NAME = 'access-tokens';
 export const DBMS_DIR_NAME = 'dbmss';
 export const BACKUPS_DIR_NAME = 'backups';
-export const PLUGIN_SOURCES_DIR_NAME = 'plugins';
+export const PLUGIN_SOURCES_DIR_NAME = 'plugin-sources';
 export const NEW_LINE = '\n';
 export const PROPERTIES_SEPARATOR = '=';
 // @todo: this should be generated when installing relate instance

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.abstract.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.abstract.ts
@@ -15,12 +15,6 @@ export abstract class DbmsPluginsAbstract<Env extends EnvironmentAbstract> {
     constructor(protected readonly environment: Env) {}
 
     /**
-     * Get the source for a specific plugin
-     * @param   name
-     */
-    abstract getSource(name: string): Promise<IDbmsPluginSource>;
-
-    /**
      * List all plugin sources
      * @param   filters     Filters to apply
      */
@@ -30,7 +24,7 @@ export abstract class DbmsPluginsAbstract<Env extends EnvironmentAbstract> {
      * Add one or more plugin sources
      * @param   sources     List of sources
      */
-    abstract addSources(sources: IDbmsPluginSource[]): Promise<List<IDbmsPluginSource>>;
+    abstract addSources(sources: Omit<IDbmsPluginSource, 'isOfficial'>[]): Promise<List<IDbmsPluginSource>>;
 
     /**
      * Remove one or more plugin sources

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.abstract.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.abstract.ts
@@ -28,15 +28,15 @@ export abstract class DbmsPluginsAbstract<Env extends EnvironmentAbstract> {
 
     /**
      * Add one or more plugin sources
-     * @param   urls     List of source URLs
+     * @param   sources     List of sources
      */
-    abstract addSources(urls: string[]): Promise<List<IDbmsPluginSource>>;
+    abstract addSources(sources: IDbmsPluginSource[]): Promise<List<IDbmsPluginSource>>;
 
     /**
      * Remove one or more plugin sources
      * @param   urls     List of source URLs
      */
-    abstract removeSources(urls: string[]): Promise<List<IDbmsPluginSource>>;
+    abstract removeSources(names: string[]): Promise<List<IDbmsPluginSource>>;
 
     /**
      * List all plugins installed in the specified DBMS

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
@@ -65,6 +65,7 @@ describe('LocalDbmsPlugins', () => {
     test('dbmsPlugins.addSources - fails when adding an already existing source', async () => {
         nock(PLUGIN_SOURCES_ORIGIN)
             .get(PLUGIN_SOURCES_PATHNAME)
+            .twice()
             .reply(200, {
                 apoc: TEST_SOURCE,
             });
@@ -75,12 +76,18 @@ describe('LocalDbmsPlugins', () => {
         );
 
         const listedSources = await app.environment.dbmsPlugins.listSources();
-        expect(listedSources.toArray()).toEqual([]);
+        expect(listedSources.toArray()).toEqual([
+            {
+                ...TEST_SOURCE,
+                isOfficial: true,
+            },
+        ]);
     });
 
     test('dbmsPlugins.addSources', async () => {
         nock(PLUGIN_SOURCES_ORIGIN)
             .get(PLUGIN_SOURCES_PATHNAME)
+            .twice()
             .reply(200, {});
 
         const addedSources = await app.environment.dbmsPlugins.addSources([TEST_SOURCE]);
@@ -97,6 +104,7 @@ describe('LocalDbmsPlugins', () => {
     test('dbmsPlugins.addSources - isOfficial attribute is ignored when adding sources', async () => {
         nock(PLUGIN_SOURCES_ORIGIN)
             .get(PLUGIN_SOURCES_PATHNAME)
+            .twice()
             .reply(200, {});
 
         const addedSources = await app.environment.dbmsPlugins.addSources([

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
@@ -28,14 +28,14 @@ describe('LocalPlugins', () => {
             .get(PLUGIN_SOURCES_PATHNAME)
             .reply(200, {});
 
-        const pluginSourcesNoDefaults = await app.environment.plugins.listSources();
+        const pluginSourcesNoDefaults = await app.environment.dbmsPlugins.listSources();
         expect(pluginSourcesNoDefaults.toArray()).toEqual([]);
 
         nock(PLUGIN_SOURCES_ORIGIN)
             .get(PLUGIN_SOURCES_PATHNAME)
             .reply(500);
 
-        const pluginSourcesFetchError = await app.environment.plugins.listSources();
+        const pluginSourcesFetchError = await app.environment.dbmsPlugins.listSources();
         expect(pluginSourcesFetchError.toArray()).toEqual([]);
     });
 
@@ -46,7 +46,7 @@ describe('LocalPlugins', () => {
                 apoc: TEST_SOURCE,
             });
 
-        const pluginSources = await app.environment.plugins.listSources();
+        const pluginSources = await app.environment.dbmsPlugins.listSources();
         expect(pluginSources.toArray()).toEqual([
             {
                 ...TEST_SOURCE,
@@ -60,8 +60,8 @@ describe('LocalPlugins', () => {
             .get(PLUGIN_SOURCES_PATHNAME)
             .reply(200, {});
 
-        const addedSources = await app.environment.plugins.addSources([TEST_SOURCE]);
-        const listedSources = await app.environment.plugins.listSources();
+        const addedSources = await app.environment.dbmsPlugins.addSources([TEST_SOURCE]);
+        const listedSources = await app.environment.dbmsPlugins.listSources();
 
         expect(addedSources.toArray()).toEqual([TEST_SOURCE]);
         expect(listedSources.toArray()).toEqual([TEST_SOURCE]);
@@ -73,8 +73,8 @@ describe('LocalPlugins', () => {
             .twice()
             .reply(200, {});
 
-        const removedSources = await app.environment.plugins.removeSources(['apoc']);
-        const listedSources = await app.environment.plugins.listSources();
+        const removedSources = await app.environment.dbmsPlugins.removeSources(['apoc']);
+        const listedSources = await app.environment.dbmsPlugins.listSources();
 
         expect(removedSources.toArray()).toEqual([TEST_SOURCE]);
         expect(listedSources.toArray()).toEqual([]);
@@ -88,8 +88,8 @@ describe('LocalPlugins', () => {
                 apoc: TEST_SOURCE,
             });
 
-        const removedSources = await app.environment.plugins.removeSources(['apoc']);
-        const listedSources = await app.environment.plugins.listSources();
+        const removedSources = await app.environment.dbmsPlugins.removeSources(['apoc']);
+        const listedSources = await app.environment.dbmsPlugins.listSources();
 
         expect(removedSources.toArray()).toEqual([]);
         expect(listedSources.toArray()).toEqual([

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.local.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.local.ts
@@ -1,13 +1,12 @@
 import fse from 'fs-extra';
-import got from 'got';
 import path from 'path';
-import {Dict, List} from '@relate/types';
+import {List} from '@relate/types';
 
 import {IDbmsPluginSource, IDbmsPluginVersion, DbmsPluginSourceModel} from '../../models';
 import {applyEntityFilters, IRelateFilter} from '../../utils/generic';
 import {NotFoundError, NotSupportedError} from '../../errors';
 import {DbmsPluginsAbstract} from './dbms-plugins.abstract';
-import {discoverPluginSources} from '../../utils/dbms-plugins';
+import {discoverPluginSources, fetchOfficialPluginSources} from '../../utils/dbms-plugins';
 import {LocalEnvironment} from '../environments';
 import {JSON_FILE_EXTENSION} from '../../constants';
 
@@ -26,19 +25,24 @@ export class LocalDbmsPlugins extends DbmsPluginsAbstract<LocalEnvironment> {
     }
 
     public async listSources(filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IDbmsPluginSource>> {
-        // @todo - should throttle this
-        this.sources = await discoverPluginSources(this.environment.dirPaths.pluginSources);
+        const official = await fetchOfficialPluginSources();
+        const userSaved = await discoverPluginSources(this.environment.dirPaths.pluginSources);
+        const allSources = official.concat(userSaved);
 
-        return applyEntityFilters(Dict.from(this.sources).values, filters);
+        this.sources = allSources.reduce((agg, source) => {
+            return {
+                ...agg,
+                [source.name]: source,
+            };
+        }, {});
+
+        return applyEntityFilters(allSources, filters);
     }
 
-    public async addSources(urls: string[]): Promise<List<IDbmsPluginSource>> {
-        const responses: List<IDbmsPluginSource> = await List.from(urls)
-            .mapEach((url) => got(url).json())
-            .unwindPromises();
-        const sources = responses.mapEach((res) => new DbmsPluginSourceModel(res));
+    public async addSources(sources: IDbmsPluginSource[]): Promise<List<IDbmsPluginSource>> {
+        const mappedSources = List.from(sources).mapEach((source) => new DbmsPluginSourceModel(source));
 
-        await sources
+        await mappedSources
             .mapEach(async (source) => {
                 const sourcePath = path.join(
                     this.environment.dirPaths.pluginSources,
@@ -49,15 +53,14 @@ export class LocalDbmsPlugins extends DbmsPluginsAbstract<LocalEnvironment> {
             })
             .unwindPromises();
 
-        return sources;
+        return mappedSources;
     }
 
     public async removeSources(names: string[]): Promise<List<IDbmsPluginSource>> {
-        const sources = await List.from(names)
-            .mapEach((name) => this.getSource(name))
-            .unwindPromises();
+        const sourcesList = await this.listSources();
+        const removedSources = sourcesList.filter((source) => names.includes(source.name) && !source.isOfficial);
 
-        await sources
+        await removedSources
             .mapEach(async (source) => {
                 const sourcePath = path.join(
                     this.environment.dirPaths.pluginSources,
@@ -68,7 +71,7 @@ export class LocalDbmsPlugins extends DbmsPluginsAbstract<LocalEnvironment> {
             })
             .unwindPromises();
 
-        return sources;
+        return removedSources;
     }
 
     public list(

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.remote.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.remote.ts
@@ -15,11 +15,11 @@ export class RemoteDbmsPlugins extends DbmsPluginsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteDbmsPlugins.name} does not support listing plugin sources`);
     }
 
-    public addSources(_urls: string[]): Promise<List<IDbmsPluginSource>> {
+    public addSources(_sources: IDbmsPluginSource[]): Promise<List<IDbmsPluginSource>> {
         throw new NotSupportedError(`${RemoteDbmsPlugins.name} does not support adding plugin sources`);
     }
 
-    public removeSources(_urls: string[]): Promise<List<IDbmsPluginSource>> {
+    public removeSources(_names: string[]): Promise<List<IDbmsPluginSource>> {
         throw new NotSupportedError(`${RemoteDbmsPlugins.name} does not support removing plugin sources`);
     }
 

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.remote.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.remote.ts
@@ -7,15 +7,11 @@ import {DbmsPluginsAbstract} from './dbms-plugins.abstract';
 import {RemoteEnvironment} from '../environments';
 
 export class RemoteDbmsPlugins extends DbmsPluginsAbstract<RemoteEnvironment> {
-    public getSource(_name: string): Promise<IDbmsPluginSource> {
-        throw new NotSupportedError(`${RemoteDbmsPlugins.name} does not support getting plugin sources`);
-    }
-
     public listSources(_filters?: List<IRelateFilter> | IRelateFilter[]): Promise<List<IDbmsPluginSource>> {
         throw new NotSupportedError(`${RemoteDbmsPlugins.name} does not support listing plugin sources`);
     }
 
-    public addSources(_sources: IDbmsPluginSource[]): Promise<List<IDbmsPluginSource>> {
+    public addSources(_sources: Omit<IDbmsPluginSource, 'isOfficial'>[]): Promise<List<IDbmsPluginSource>> {
         throw new NotSupportedError(`${RemoteDbmsPlugins.name} does not support adding plugin sources`);
     }
 

--- a/packages/common/src/entities/environments/environment.abstract.ts
+++ b/packages/common/src/entities/environments/environment.abstract.ts
@@ -19,9 +19,12 @@ import {ProjectsAbstract} from '../projects';
 import {BackupAbstract} from '../backups';
 import {envPaths} from '../../utils';
 import {PUBLIC_GRAPHQL_METHODS} from '../../constants';
+import {DbmsPluginsAbstract} from '../dbms-plugins';
 
 export abstract class EnvironmentAbstract {
     public readonly dbmss!: DbmssAbstract<EnvironmentAbstract>;
+
+    public readonly dbmsPlugins!: DbmsPluginsAbstract<EnvironmentAbstract>;
 
     public readonly dbs!: DbsAbstract<EnvironmentAbstract>;
 

--- a/packages/common/src/entities/environments/environment.constants.ts
+++ b/packages/common/src/entities/environments/environment.constants.ts
@@ -39,6 +39,8 @@ export const ZULU_JAVA_DOWNLOAD_URL = 'https://cdn.azul.com/zulu/bin/';
 export const NEO4J_BIN_DIR = 'bin';
 export const NEO4J_BIN_FILE = process.platform === 'win32' ? 'neo4j.bat' : 'neo4j';
 export const NEO4J_ADMIN_BIN_FILE = process.platform === 'win32' ? 'neo4j-admin.bat' : 'neo4j-admin';
+export const NEO4J_PLUGIN_SOURCES_URL =
+    'https://raw.githubusercontent.com/neo4j/docker-neo4j/master/neo4jlabs-plugins.json';
 export const NEO4J_DIST_VERSIONS_URL = 'https://dist.neo4j.org/versions/v1/neo4j-versions.json';
 export const NEO4J_DIST_LIMITED_VERSIONS_URL = 'https://dist.neo4j.org/versions/v1/neo4j-limited-versions.json';
 export const NEO4J_CONF_DIR = 'conf';

--- a/packages/common/src/entities/environments/environment.local.ts
+++ b/packages/common/src/entities/environments/environment.local.ts
@@ -47,7 +47,7 @@ export class LocalEnvironment extends EnvironmentAbstract {
         extensionsCache: path.join(this.cachePath, EXTENSION_DIR_NAME),
         extensionsData: path.join(this.dataPath, EXTENSION_DIR_NAME),
         staticExtensionsData: path.join(this.dataPath, EXTENSION_DIR_NAME, EXTENSION_TYPES.STATIC),
-        pluginSources: path.join(envPaths().config, PLUGIN_SOURCES_DIR_NAME),
+        pluginSources: path.join(this.dataPath, PLUGIN_SOURCES_DIR_NAME),
     };
 
     public getEntityRootPath(entityType: ENTITY_TYPES, id: string): string {

--- a/packages/common/src/entities/environments/environment.local.ts
+++ b/packages/common/src/entities/environments/environment.local.ts
@@ -27,6 +27,8 @@ import {getManifestName} from '../../utils/system';
 export class LocalEnvironment extends EnvironmentAbstract {
     public readonly dbmss = new LocalDbmss(this);
 
+    public readonly dbmsPlugins = new LocalDbmsPlugins(this);
+
     public readonly dbs = new LocalDbs(this);
 
     public readonly extensions = new LocalExtensions(this);
@@ -34,8 +36,6 @@ export class LocalEnvironment extends EnvironmentAbstract {
     public readonly projects = new LocalProjects(this);
 
     public readonly backups = new LocalBackups(this);
-
-    public readonly plugins = new LocalDbmsPlugins(this);
 
     public readonly dirPaths = {
         ...envPaths(),

--- a/packages/common/src/entities/environments/environment.remote.ts
+++ b/packages/common/src/entities/environments/environment.remote.ts
@@ -14,9 +14,12 @@ import {RemoteProjects} from '../projects';
 import {RemoteDbs} from '../dbs';
 import {RemoteBackups} from '../backups';
 import {GraphQLClient, GraphQLAbstract} from '../../utils/graphql';
+import {RemoteDbmsPlugins} from '../dbms-plugins';
 
 export class RemoteEnvironment extends EnvironmentAbstract {
     public readonly dbmss = new RemoteDbmss(this);
+
+    public readonly dbmsPlugins = new RemoteDbmsPlugins(this);
 
     public readonly dbs = new RemoteDbs(this);
 

--- a/packages/common/src/models/dbms-plugin.model.ts
+++ b/packages/common/src/models/dbms-plugin.model.ts
@@ -1,5 +1,5 @@
 import {assign} from 'lodash';
-import {IsHash, IsOptional, IsSemVer, IsString, IsUrl} from 'class-validator';
+import {IsBoolean, IsHash, IsOptional, IsSemVer, IsString, IsUrl} from 'class-validator';
 
 import {ModelAbstract, StringOrStringArray} from './model.abstract';
 
@@ -12,6 +12,9 @@ export interface IDbmsPluginSource {
 
     /** URL from which to fetch available plugin versions */
     versionsUrl: string;
+
+    /** Whether the plugin source is officially supported */
+    isOfficial?: boolean;
 }
 
 export interface IDbmsPluginVersion {
@@ -43,6 +46,10 @@ export class DbmsPluginSourceModel extends ModelAbstract<IDbmsPluginSource> impl
 
     @IsUrl()
     public versionsUrl!: string;
+
+    @IsOptional()
+    @IsBoolean()
+    public isOfficial?: boolean;
 }
 
 export class DbmsPluginVersionModel extends ModelAbstract<IDbmsPluginVersion> implements IDbmsPluginVersion {

--- a/packages/common/src/utils/dbms-plugins/discover-plugins.ts
+++ b/packages/common/src/utils/dbms-plugins/discover-plugins.ts
@@ -1,13 +1,34 @@
 import fse from 'fs-extra';
 import got from 'got';
 import path from 'path';
-import {Dict, List} from '@relate/types';
+import {List} from '@relate/types';
+import {isArray, isObject} from 'lodash';
 
 import {IDbmsPluginSource, IDbmsPluginVersion, DbmsPluginSourceModel, DbmsPluginVersionModel} from '../../models';
-import {isArray} from 'lodash';
+import {NEO4J_PLUGIN_SOURCES_URL} from '../../entities/environments';
 
-export const discoverPluginSources = async (rootDir: string): Promise<Record<string, IDbmsPluginSource>> => {
-    const sources = await List.from(await fse.readdir(rootDir))
+export const fetchOfficialPluginSources = async (): Promise<List<IDbmsPluginSource>> => {
+    const rawSourcesMap = await got(NEO4J_PLUGIN_SOURCES_URL)
+        .json()
+        .catch(() => null);
+
+    if (!rawSourcesMap || !isObject(rawSourcesMap)) {
+        // @todo - should we check the cache here before returning an empty list?
+        return List.from([]);
+    }
+
+    return List.from(Object.entries(rawSourcesMap)).mapEach(([name, source]) => {
+        return new DbmsPluginSourceModel({
+            ...source,
+            name,
+            isOfficial: true,
+        });
+    });
+};
+
+export const discoverPluginSources = async (rootDir: string): Promise<List<IDbmsPluginSource>> => {
+    const sourcesFiles = await fse.readdir(rootDir);
+    const sourcesList = await List.from(sourcesFiles)
         .filter((filename) => filename.endsWith('.json'))
         .mapEach(async (filename) => {
             const filepath = path.join(rootDir, filename);
@@ -17,7 +38,7 @@ export const discoverPluginSources = async (rootDir: string): Promise<Record<str
         })
         .unwindPromises();
 
-    return Dict.from(sources.mapEach((source): [string, IDbmsPluginSource] => [source.name, source])).toObject();
+    return sourcesList;
 };
 
 export const fetchPluginVersions = async (versionsUrl: string): Promise<List<IDbmsPluginVersion> | null> => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Fixed the implementation for plugin sources to follow the [DBMS plugins RFC](https://github.com/neo4j-devtools/relate/blob/5af3f9d4b9360c26576cfc7414b26a79807c4cfb/documentation/RFCs/dbms-plugins/dbms-plugins.rfc.md).


### What is the current behavior?
- List sources only from the file system
- Adding sources requires a list of URLs to indirection files, each containing one or more sources


### What is the new behavior?
- Get default sources from [neo4jlabs-plugins.json](https://raw.githubusercontent.com/neo4j/docker-neo4j/master/neo4jlabs-plugins.json), and user sources from the file system
- Adding sources requires a list of `IDbmsPluginSource` objects each representing a single source
- More edge cases covered


### Does this PR introduce a breaking change?
Yes, the implementation and interface for plugin sources are changed.


### Other information:
