### PR TITLE
Fix downloading of sample projects.

### DIFF
--- a/packages/common/src/entities/projects/projects.abstract.ts
+++ b/packages/common/src/entities/projects/projects.abstract.ts
@@ -135,7 +135,11 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
     /**
      * Download sample project from github (https://github.com/neo4j-graph-examples)
      */
-    abstract downloadSampleProject(selected: string, destPath?: string): Promise<{path: string; temp: boolean}>;
+    abstract downloadSampleProject(
+        url: string,
+        name: string,
+        destPath?: string,
+    ): Promise<{path: string; temp: boolean}>;
 
     /**
      * Install sample project from file

--- a/packages/common/src/entities/projects/projects.local.ts
+++ b/packages/common/src/entities/projects/projects.local.ts
@@ -305,10 +305,14 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
 
             // @TODO: Figure out how to filter the response by topic or something else.
             return List.from(
-                JSON.parse(response.body).map(({name, description}: ISampleProjectRest) => ({
+                /* eslint-disable-next-line camelcase, @typescript-eslint/camelcase */
+                JSON.parse(response.body).map(({name, description, default_branch}: ISampleProjectRest) => ({
                     name,
                     description,
-                    downloadUrl: `https://github.com/neo4j-graph-examples/${name}/archive/master.zip`,
+                    /* eslint-disable-next-line camelcase, @typescript-eslint/camelcase */
+                    default_branch,
+                    /* eslint-disable-next-line camelcase, @typescript-eslint/camelcase */
+                    downloadUrl: `https://github.com/neo4j-graph-examples/${name}/archive/${default_branch}.zip`,
                 })),
             );
         } catch (_error) {
@@ -316,14 +320,11 @@ export class LocalProjects extends ProjectsAbstract<LocalEnvironment> {
         }
     }
 
-    async downloadSampleProject(selected: string, destPath?: string): Promise<{path: string; temp: boolean}> {
+    async downloadSampleProject(url: string, name: string, destPath?: string): Promise<{path: string; temp: boolean}> {
         const {tmp} = this.environment.dirPaths;
 
-        const diskPath = destPath || path.join(tmp, 'sample-project');
-        const sampleProject = await download(
-            `https://github.com/neo4j-graph-examples/${selected}/archive/master.zip`,
-            destPath ? destPath : path.join(diskPath, selected),
-        );
+        const diskPath = destPath || path.join(tmp, uuidv4());
+        const sampleProject = await download(url, destPath ? destPath : path.join(diskPath, name));
 
         const extractedPath = await extract(sampleProject, diskPath);
 

--- a/packages/common/src/entities/projects/projects.remote.ts
+++ b/packages/common/src/entities/projects/projects.remote.ts
@@ -85,7 +85,7 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support listing sample projects`);
     }
 
-    downloadSampleProject(_selected: string, _destPath?: string): Promise<{path: string; temp: boolean}> {
+    downloadSampleProject(_url: string, _name: string, _destPath?: string): Promise<{path: string; temp: boolean}> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support downloading sample projects`);
     }
 

--- a/packages/common/src/models/project-install.model.ts
+++ b/packages/common/src/models/project-install.model.ts
@@ -30,6 +30,8 @@ export interface ISampleProjectRest {
     name: string;
     description: string;
     downloadUrl: string;
+    /* eslint-disable-next-line camelcase */
+    default_branch: string;
 }
 
 export class ProjectInstallManifestModel extends ManifestModel<ISampleProject> implements ISampleProjectManifest {


### PR DESCRIPTION
This addresses an issue where sample projects couldn't be downloaded when the default branch had been renamed from master to something else.

### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
This is a fix for installing Sample projects. It changes the assumption that the default branch of a repo at `neo4j-graph-examples` is `master` and now instead uses `default_branch` from the GitHub API to determine the download URL.


### What is the current behavior?
`master` is hardcoded in the download URL.


### What is the new behavior?
(if this is a feature change)


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)


### Other information:
