### PR TITLE
Fix dbms.info always returning "offline" when changing ports

### DIFF
--- a/packages/common/src/entities/dbmss/dbmss.local.ts
+++ b/packages/common/src/entities/dbmss/dbmss.local.ts
@@ -434,7 +434,13 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
                 }
 
                 if (onlineCheck && status === DBMS_STATUS.STARTED) {
-                    serverStatus = (await isDbmsOnline(dbms)) ? DBMS_SERVER_STATUS.ONLINE : DBMS_SERVER_STATUS.OFFLINE;
+                    const config = await this.getDbmsConfig(dbms.id);
+                    serverStatus = (await isDbmsOnline({
+                        ...dbms,
+                        config,
+                    }))
+                        ? DBMS_SERVER_STATUS.ONLINE
+                        : DBMS_SERVER_STATUS.OFFLINE;
                 }
 
                 return {

--- a/packages/common/src/entities/dbmss/info.test.ts
+++ b/packages/common/src/entities/dbmss/info.test.ts
@@ -1,0 +1,67 @@
+import {TestDbmss} from '../../utils/system';
+import {IDbmsInfo} from '../../models';
+import {EnvironmentAbstract} from '../environments';
+import {waitForDbmsToBeOnline} from '../../utils/dbmss';
+
+describe('LocalDbmss - info', () => {
+    let testDbmss: TestDbmss;
+    let env: EnvironmentAbstract;
+    let dbms: IDbmsInfo;
+
+    beforeAll(async () => {
+        testDbmss = await TestDbmss.init(__filename);
+        env = testDbmss.environment;
+        dbms = await testDbmss.createDbms();
+    });
+
+    afterAll(async () => {
+        await testDbmss.teardown();
+    });
+
+    test('Get DBMS info', async () => {
+        const info = await env.dbmss.info([dbms.id]);
+
+        expect(info.toArray()).toEqual([dbms]);
+    });
+
+    test('Get DBMS info with online check (offline)', async () => {
+        const info = await env.dbmss.info([dbms.id], true);
+
+        expect(info.toArray()).toEqual([
+            {
+                ...dbms,
+                serverStatus: 'offline',
+            },
+        ]);
+    });
+
+    test('Get DBMS info (unknown server status)', async () => {
+        await env.dbmss.start([dbms.id]);
+        await waitForDbmsToBeOnline({
+            ...dbms,
+            config: await env.dbmss.getDbmsConfig(dbms.id),
+        });
+
+        const info = await env.dbmss.info([dbms.id]);
+
+        expect(info.toArray()).toEqual([
+            {
+                ...dbms,
+                serverStatus: 'unknown',
+                status: 'started',
+            },
+        ]);
+    });
+
+    test('Get DBMS info with online check (online)', async () => {
+        const info = await env.dbmss.info([dbms.id], true);
+
+        expect(info.toArray()).toEqual([
+            {
+                ...dbms,
+                serverStatus: 'online',
+                status: 'started',
+            },
+        ]);
+    });
+});


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix


### What is the current behavior?
If the DBMS config is changed to use different ports while the application is running, the `dbmss.info` method will always return `serverStatus === "offline"` (when performing the online check). This is because we read the DBMS config once, before it's changed, and perform the check against the ports specified there.

### What is the new behavior?
Add tests for `dbmss.info` and read the config before checking if the DBMS is online.


### Does this PR introduce a breaking change?
No


### Other information:
