### PR TITLE
Update sources list URL and remove mocks on e2e tests

### DIFF
--- a/packages/common/src/entities/environments/environment.constants.ts
+++ b/packages/common/src/entities/environments/environment.constants.ts
@@ -39,8 +39,7 @@ export const ZULU_JAVA_DOWNLOAD_URL = 'https://cdn.azul.com/zulu/bin/';
 export const NEO4J_BIN_DIR = 'bin';
 export const NEO4J_BIN_FILE = process.platform === 'win32' ? 'neo4j.bat' : 'neo4j';
 export const NEO4J_ADMIN_BIN_FILE = process.platform === 'win32' ? 'neo4j-admin.bat' : 'neo4j-admin';
-export const NEO4J_PLUGIN_SOURCES_URL =
-    'https://raw.githubusercontent.com/neo4j/docker-neo4j/master/neo4jlabs-plugins.json';
+export const NEO4J_PLUGIN_SOURCES_URL = 'https://dist.neo4j.org/relate/official-plugin-sources.json';
 export const NEO4J_DIST_VERSIONS_URL = 'https://dist.neo4j.org/versions/v1/neo4j-versions.json';
 export const NEO4J_DIST_LIMITED_VERSIONS_URL = 'https://dist.neo4j.org/versions/v1/neo4j-limited-versions.json';
 export const NEO4J_CONF_DIR = 'conf';


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Refactoring


### What is the current behavior?
- The URL for official plugin sources is pointing to the file used by the Neo4j docker image. 
- Calls to the official plugin sources URL are mocked in the e2e tests.

### What is the new behavior?
- The URL for official plugin sources is pointing to a [file](https://dist.neo4j.org/relate/official-plugin-sources.json) we're hosting on S3. 
- Calls to the official plugin sources URL are not mocked in the e2e tests.


### Does this PR introduce a breaking change?
No


### Other information:
