### PR TITLE
CLI: simplify environment initialization

### DIFF
--- a/packages/cli/docs/environment.md
+++ b/packages/cli/docs/environment.md
@@ -51,6 +51,7 @@ ARGUMENTS
 
 OPTIONS
   -i, --interactive      Get prompted for each configuration option available
+  --noRuntime            Skip downloading the Java runtime required by the DBMS
   --type=(LOCAL|REMOTE)  Type of environment
   --use                  Set environment as active right after creating it
 

--- a/packages/cli/docs/environment.md
+++ b/packages/cli/docs/environment.md
@@ -4,7 +4,7 @@
 Managed sets of related resources and services, which may be local or remote.
 
 * [`relate environment:api-token [CLIENTID]`](#relate-environmentapi-token-clientid)
-* [`relate environment:init`](#relate-environmentinit)
+* [`relate environment:init [ENVIRONMENT] [HTTPORIGIN]`](#relate-environmentinit-environment-httporigin)
 * [`relate environment:list`](#relate-environmentlist)
 * [`relate environment:login [ENVIRONMENT]`](#relate-environmentlogin-environment)
 * [`relate environment:open [ENVIRONMENT]`](#relate-environmentopen-environment)
@@ -37,26 +37,31 @@ EXAMPLES
 
 _See code: [dist/commands/environment/api-token.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.22/packages/cli/src/commands/environment/api-token.ts)_
 
-## `relate environment:init`
+## `relate environment:init [ENVIRONMENT] [HTTPORIGIN]`
 
 Initialize a new relate environment
 
 ```
 USAGE
-  $ relate environment:init
+  $ relate environment:init [ENVIRONMENT] [HTTPORIGIN]
+
+ARGUMENTS
+  ENVIRONMENT  Name of the environment to run the command against
+  HTTPORIGIN   URL of the hosted instance of relate (only applies to --type=REMOTE)
 
 OPTIONS
-  --httpOrigin=httpOrigin  URL of the hosted instance of relate (only applies to --type=REMOTE)
-  --name=name              (required) Name of the environment to initialize
-  --type=(LOCAL|REMOTE)    (required) Type of environment
+  -i, --interactive      Get prompted for each configuration option available
+  --type=(LOCAL|REMOTE)  Type of environment
+  --use                  Set environment as active right after creating it
 
 ALIASES
   $ relate env:init
 
 EXAMPLES
-  $ relate env:init
-  $ relate env:init --name=local-environment-name --type=LOCAL
-  $ relate env:init --name=remote-environment-name --type=REMOTE --httpOrigin=https://url.of.hosted.relate.com
+  $ relate env:init local-environment-name
+  $ relate env:init local-environment-name --use
+  $ relate env:init remote-environment-name https://url.of.hosted.relate.com --type=REMOTE
+  $ relate env:init environment-name --interactive
 ```
 
 _See code: [dist/commands/environment/init.ts](https://github.com/neo4j-devtools/relate/blob/v1.0.2-alpha.22/packages/cli/src/commands/environment/init.ts)_

--- a/packages/cli/docs/environment.md
+++ b/packages/cli/docs/environment.md
@@ -51,8 +51,14 @@ ARGUMENTS
 
 OPTIONS
   -i, --interactive      Get prompted for each configuration option available
+
+  --apiToken             If this flag is provided and the environment created is set as active, all requests to
+                         @relate/web will require API tokens
+
   --noRuntime            Skip downloading the Java runtime required by the DBMS
+
   --type=(LOCAL|REMOTE)  Type of environment
+
   --use                  Set environment as active right after creating it
 
 ALIASES

--- a/packages/cli/src/commands/environment/init.ts
+++ b/packages/cli/src/commands/environment/init.ts
@@ -45,5 +45,10 @@ export default class InitCommand extends BaseCommand {
         noRuntime: flags.boolean({
             description: 'Skip downloading the Java runtime required by the DBMS',
         }),
+        apiToken: flags.boolean({
+            description:
+                // eslint-disable-next-line max-len
+                'If this flag is provided and the environment created is set as active, all requests to @relate/web will require API tokens',
+        }),
     };
 }

--- a/packages/cli/src/commands/environment/init.ts
+++ b/packages/cli/src/commands/environment/init.ts
@@ -35,12 +35,15 @@ export default class InitCommand extends BaseCommand {
             description: 'Type of environment',
             options: Object.values(ENVIRONMENT_TYPES),
         }),
-        use: flags.boolean({
-            description: 'Set environment as active right after creating it',
-        }),
         interactive: flags.boolean({
             description: 'Get prompted for each configuration option available',
             char: 'i',
+        }),
+        use: flags.boolean({
+            description: 'Set environment as active right after creating it',
+        }),
+        noRuntime: flags.boolean({
+            description: 'Skip downloading the Java runtime required by the DBMS',
         }),
     };
 }

--- a/packages/cli/src/commands/environment/init.ts
+++ b/packages/cli/src/commands/environment/init.ts
@@ -2,7 +2,7 @@ import {flags} from '@oclif/command';
 import {ENVIRONMENT_TYPES} from '@relate/common';
 
 import BaseCommand from '../../base.command';
-import {REQUIRED_FOR_SCRIPTS} from '../../constants';
+import {ARGS} from '../../constants';
 import {InitModule} from '../../modules/environment/init.module';
 
 export default class InitCommand extends BaseCommand {
@@ -13,25 +13,34 @@ export default class InitCommand extends BaseCommand {
     static description = 'Initialize a new relate environment';
 
     static examples = [
-        '$ relate env:init',
-        '$ relate env:init --name=local-environment-name --type=LOCAL',
-        '$ relate env:init --name=remote-environment-name --type=REMOTE --httpOrigin=https://url.of.hosted.relate.com',
+        '$ relate env:init local-environment-name',
+        '$ relate env:init local-environment-name --use',
+        '$ relate env:init remote-environment-name https://url.of.hosted.relate.com --type=REMOTE',
+        '$ relate env:init environment-name --interactive',
     ];
 
     static aliases = ['env:init'];
 
+    static args = [
+        ARGS.ENVIRONMENT,
+        {
+            description: 'URL of the hosted instance of relate (only applies to --type=REMOTE)',
+            name: 'httpOrigin',
+            required: false,
+        },
+    ];
+
     static flags = {
-        httpOrigin: flags.string({
-            description: `URL of the hosted instance of relate (only applies to --type=${ENVIRONMENT_TYPES.REMOTE})`,
-        }),
-        name: flags.string({
-            description: 'Name of the environment to initialize',
-            required: REQUIRED_FOR_SCRIPTS,
-        }),
         type: flags.enum({
             description: 'Type of environment',
             options: Object.values(ENVIRONMENT_TYPES),
-            required: REQUIRED_FOR_SCRIPTS,
+        }),
+        use: flags.boolean({
+            description: 'Set environment as active right after creating it',
+        }),
+        interactive: flags.boolean({
+            description: 'Get prompted for each configuration option available',
+            char: 'i',
         }),
     };
 }

--- a/packages/cli/src/modules/dbms/upgrade.module.ts
+++ b/packages/cli/src/modules/dbms/upgrade.module.ts
@@ -23,7 +23,7 @@ export class UpgradeModule implements OnApplicationBootstrap {
 
     registerHookListeners() {
         const downloadBar = cli.progress({
-            format: 'DOWNLOAD PROGRESS [{bar}] {percentage}%',
+            format: 'Download progress [{bar}] {percentage}%',
             barCompleteChar: '\u2588',
             barIncompleteChar: '\u2591',
         });

--- a/packages/cli/src/modules/environment/environment.local.e2e.ts
+++ b/packages/cli/src/modules/environment/environment.local.e2e.ts
@@ -9,10 +9,12 @@ import ListCommand from '../../commands/environment/list';
 
 const TEST_ENV_NAME = 'test';
 const ENV_NAME = 'test2';
+const ENV_NAME_2 = 'test3';
 
 describe('$relate environment', () => {
     afterAll(async () => {
         await fse.unlink(path.join(envPaths().config, ENVIRONMENTS_DIR_NAME, `${ENV_NAME}.json`));
+        await fse.unlink(path.join(envPaths().config, ENVIRONMENTS_DIR_NAME, `${ENV_NAME_2}.json`));
     });
 
     describe('list, before init', () => {
@@ -24,11 +26,23 @@ describe('$relate environment', () => {
     });
 
     describe('init', () => {
-        test.stderr().it('creates environment', async (ctx) => {
-            await InitCommand.run([`--name=${ENV_NAME}`, '--type=LOCAL']);
+        test.stdout()
+            .stderr()
+            .it('creates environment', async (ctx) => {
+                await InitCommand.run([`${ENV_NAME}`, '--type=LOCAL']);
 
-            expect(ctx.stderr).toContain('done');
-        });
+                expect(ctx.stderr).toContain('done');
+                expect(ctx.stdout).not.toContain(`Environment "${ENV_NAME}" is now set as active.`);
+            });
+
+        test.stdout()
+            .stderr()
+            .it('creates environment and activates it', async (ctx) => {
+                await InitCommand.run([`${ENV_NAME_2}`, '--type=LOCAL', '--use']);
+
+                expect(ctx.stderr).toContain('done');
+                expect(ctx.stdout).toContain(`Environment "${ENV_NAME_2}" is now set as active.`);
+            });
     });
 
     describe('list, after init', () => {

--- a/packages/cli/src/modules/environment/init.module.ts
+++ b/packages/cli/src/modules/environment/init.module.ts
@@ -18,7 +18,6 @@ import {
     selectAuthenticatorPrompt,
     selectPrompt,
 } from '../../prompts';
-import {isInteractive} from '../../stdin';
 
 @Module({
     exports: [],
@@ -33,19 +32,30 @@ export class InitModule implements OnApplicationBootstrap {
     ) {}
 
     async onApplicationBootstrap(): Promise<void> {
-        let {type, name, httpOrigin} = this.parsed.flags;
+        let {environment: name, httpOrigin} = this.parsed.args;
+        let {type} = this.parsed.flags;
+        const {interactive, use} = this.parsed.flags;
         let remoteEnvironmentId: string | undefined = undefined;
 
-        const envChoices = Object.values(ENVIRONMENT_TYPES).map((envType) => ({
-            name: envType,
-            message: envType.charAt(0).toLocaleUpperCase() + envType.toLocaleLowerCase().slice(1),
-        }));
-
-        type = type || (await selectPrompt('Choose environment type', envChoices));
         name = name || (await inputPrompt('Enter environment name'));
 
-        if (type === ENVIRONMENT_TYPES.REMOTE) {
-            httpOrigin = httpOrigin || (await inputPrompt('Enter remote origin (without trailing slash)'));
+        let config: IEnvironmentConfigInput = {
+            type: type || ENVIRONMENT_TYPES.LOCAL,
+            name,
+        };
+
+        if (interactive) {
+            const envChoices = Object.values(ENVIRONMENT_TYPES).map((envType) => ({
+                name: envType,
+                message: envType.charAt(0).toLocaleUpperCase() + envType.toLocaleLowerCase().slice(1),
+            }));
+
+            type = type || (await selectPrompt('Choose environment type', envChoices));
+        }
+
+        if (interactive && type === ENVIRONMENT_TYPES.REMOTE) {
+            httpOrigin = httpOrigin || (await inputPrompt('Enter remote URL (without trailing slash)'));
+
             try {
                 remoteEnvironmentId = await fetch(`${httpOrigin}${HEALTH_BASE_ENDPOINT}`)
                     .then((res) => res.json())
@@ -57,15 +67,13 @@ export class InitModule implements OnApplicationBootstrap {
             if (!remoteEnvironmentId) {
                 throw new InvalidArgumentError(`${httpOrigin} does not seem to be a valid @relate/web server instance`);
             }
-        }
 
-        if (isInteractive()) {
             const authentication = await selectAuthenticatorPrompt();
             const publicGraphQLMethods = await selectAllowedMethodsPrompt();
             const requiresAPIToken = await confirmPrompt('Are HTTP consumers required to have an API key?');
-            const config: IEnvironmentConfigInput = {
-                type,
+            config = {
                 name,
+                type,
                 httpOrigin: httpOrigin && new URL(httpOrigin).origin,
                 remoteEnvironmentId,
                 authentication,
@@ -74,19 +82,14 @@ export class InitModule implements OnApplicationBootstrap {
                     requiresAPIToken,
                 },
             };
-
-            cli.action.start('Creating environment');
-            return this.systemProvider.createEnvironment(config).then(() => cli.action.stop());
         }
 
-        const config: IEnvironmentConfigInput = {
-            type,
-            name,
-            httpOrigin: httpOrigin && new URL(httpOrigin).origin,
-            remoteEnvironmentId,
-        };
-
         cli.action.start('Creating environment');
-        return this.systemProvider.createEnvironment(config).then(() => cli.action.stop());
+        await this.systemProvider.createEnvironment(config);
+        cli.action.stop();
+
+        if (use) {
+            await this.systemProvider.useEnvironment(name);
+        }
     }
 }

--- a/packages/cli/src/modules/environment/init.module.ts
+++ b/packages/cli/src/modules/environment/init.module.ts
@@ -54,7 +54,7 @@ export class InitModule implements OnApplicationBootstrap {
     async onApplicationBootstrap(): Promise<void> {
         let {environment: name, httpOrigin} = this.parsed.args;
         let {type} = this.parsed.flags;
-        const {interactive, use, noRuntime} = this.parsed.flags;
+        const {interactive, use, noRuntime, apiToken} = this.parsed.flags;
         let remoteEnvironmentId: string | undefined = undefined;
 
         this.registerHookListeners();
@@ -92,7 +92,8 @@ export class InitModule implements OnApplicationBootstrap {
 
             const authentication = await selectAuthenticatorPrompt();
             const publicGraphQLMethods = await selectAllowedMethodsPrompt();
-            const requiresAPIToken = await confirmPrompt('Are HTTP consumers required to have an API key?');
+            const requiresAPIToken =
+                apiToken || (await confirmPrompt('Are HTTP consumers required to have an API key?'));
             config = {
                 name,
                 type,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
API improvement


### What is the current behavior?
In order to get started with Relate, new users need to: 

- Run the `env:init` command, reply to prompts about configuration options that might not be relevant to them, or that they might not understand.
- Run the `env:use` command, to set the newly created environment as active.
- If the user doesn't have Desktop installed, they'll also have to either install Java on their machine or download it and extract it in Relate's cache.


### What is the new behavior?
In order to get started with Relate, new users need to: 

- Run `relate env:init <environmentName> --use`

Default values will be used for configuration and Java will be automatically downloaded in Relate's cache if it's not already present. Also with the `--use` flag, the environment just created will also be set as active. 

For advanced users the configuration prompts are still available with the `--interactive` or `-i` flag.

### Does this PR introduce a breaking change?
Yes, the arguments and flags for `relate env:init` have changed.


### Other information:
