### PR TITLE
Cache downloaded DBMS plugins

### DIFF
--- a/packages/common/src/models/dbms-plugin.model.ts
+++ b/packages/common/src/models/dbms-plugin.model.ts
@@ -28,7 +28,7 @@ export interface IDbmsPluginVersion {
     neo4jVersion: string;
 
     /** Plugin homepage URL */
-    homepageUrl: string;
+    homepageUrl?: string;
 
     /** Plugin download URL */
     downloadUrl: string;
@@ -80,8 +80,9 @@ export class DbmsPluginVersionModel extends ModelAbstract<IDbmsPluginVersion> im
     @IsString()
     public neo4jVersion!: string;
 
+    @IsOptional()
     @IsString()
-    public homepageUrl!: string;
+    public homepageUrl?: string;
 
     // eslint-disable-next-line @typescript-eslint/camelcase,camelcase
     @IsUrl({require_tld: false})

--- a/packages/common/src/utils/dbmss/dbms-upgrade-config.ts
+++ b/packages/common/src/utils/dbmss/dbms-upgrade-config.ts
@@ -46,7 +46,7 @@ export async function dbmsUpgradeConfigs(
 
     await fse.copy(
         path.join(dbms.rootPath, NEO4J_PLUGIN_DIR),
-        path.join(dbms.rootPath, NEO4J_PLUGINS_PRE_UPGRADE_DIR),
+        path.join(upgradedDbms.rootPath, NEO4J_PLUGINS_PRE_UPGRADE_DIR),
         {
             overwrite: true,
         },


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Update types/feature

### What is the current behavior?
- Plugins are downloaded on each install
- Homepage URLs are mandatory for version objects 

### What is the new behavior?
- Plugins are cached in the same way DBMSs and other entities are cached
- Homepage URLs are optional for version objects


### Does this PR introduce a breaking change?
No
