### PR TITLE
Plugins - export Desktop required plugin utils, consts

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,6 +3,7 @@ export {IAuthToken} from '@huboneo/tapestry';
 export {IExtensionVersion, loadExtensionsFor, getAppLaunchUrl} from './utils/extensions';
 export {TestDbmss, TestExtensions, TestEnvironment} from './utils/system';
 export {GraphQLClient, GraphQLAbstract} from './utils/graphql';
+export {getLatestCompatibleVersion, listVersions} from './utils/dbms-plugins';
 export * from './system';
 export * from './models';
 export * from './errors';
@@ -19,6 +20,8 @@ export {
     NEO4J_ORIGIN,
     NEO4J_SUPPORTED_VERSION_RANGE,
     NEO4J_ACCESS_TOKEN_SUPPORT_VERSION_RANGE,
+    NEO4J_PLUGIN_SOURCES_URL,
+    NEO4J_PLUGINS_PRE_UPGRADE_DIR,
 } from './entities/environments';
 export * from './entities/environments/authentication';
 export * from './token.service';

--- a/packages/common/src/models/dbms-plugin.model.ts
+++ b/packages/common/src/models/dbms-plugin.model.ts
@@ -2,7 +2,6 @@ import {assign} from 'lodash';
 import {IsBoolean, IsHash, IsOptional, IsString, IsUrl} from 'class-validator';
 import {ModelAbstract} from './model.abstract';
 import {IsPluginConfig} from './custom-validators';
-import {IDbmsVersion} from './dbms.model';
 
 export type DbmsPluginConfig = Record<string, string | string[] | boolean | undefined>;
 
@@ -46,7 +45,7 @@ export interface IDbmsPluginInstalled extends IDbmsPluginSource {
 
 export interface IDbmsPluginUpgradable {
     installed: IDbmsPluginInstalled;
-    upgradable?: IDbmsVersion;
+    upgradable?: IDbmsPluginVersion;
 }
 
 export class DbmsPluginSourceModel extends ModelAbstract<IDbmsPluginSource> implements IDbmsPluginSource {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
exports a couple of constants and utils specific to plugins (needed in Desktop). Also changes `IDbmsPluginUpgradable upgradable` property type to be `IDbmsPluginVersion` and not `IDbmsVersion`


### What is the current behavior?
exports and constants not exported and `IDbmsVersion` type described causing issues.


### What is the new behavior?
exports constants and utils required in Desktop and changes type described above.


### Does this PR introduce a breaking change?
No


### Other information:
