### PR TITLE
Store logs for failed upgrades

### DIFF
--- a/packages/cli/src/modules/db/dump.module.ts
+++ b/packages/cli/src/modules/db/dump.module.ts
@@ -41,7 +41,7 @@ export class DumpModule implements OnApplicationBootstrap {
 
         const dateISO = new Date().toISOString();
         const [date] = dateISO.split('.');
-        const file = path.join(to || `${dbms.name}-${database}-${date.replace(/:/g, '')}.dump`);
+        const file = path.join(to || `${dbms.name}-${database}-${date.replaceAll(':', '')}.dump`);
 
         const filePath = path.resolve(file);
 

--- a/packages/cli/src/modules/db/dump.module.ts
+++ b/packages/cli/src/modules/db/dump.module.ts
@@ -41,7 +41,7 @@ export class DumpModule implements OnApplicationBootstrap {
 
         const dateISO = new Date().toISOString();
         const [date] = dateISO.split('.');
-        const file = path.join(to || `${dbms.name}-${database}-${date.replaceAll(':', '')}.dump`);
+        const file = path.join(to || `${dbms.name}-${database}-${date.replace(/:/g, '')}.dump`);
 
         const filePath = path.resolve(file);
 

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -26,6 +26,7 @@ export const EXTENSION_MANIFEST_FILE = `relate.${ENTITY_TYPES.EXTENSION}.json`;
 export const RELATE_ACCESS_TOKENS_DIR_NAME = 'access-tokens';
 export const DBMS_DIR_NAME = 'dbmss';
 export const BACKUPS_DIR_NAME = 'backups';
+export const UPGRADE_LOGS_DIR_NAME = 'upgrade-logs';
 export const PLUGINS_DIR_NAME = 'plugin';
 export const PLUGIN_SOURCES_DIR_NAME = 'plugin-sources';
 export const PLUGIN_VERSIONS_DIR_NAME = 'plugin-versions';

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -10,6 +10,7 @@ export enum ENTITY_TYPES {
     EXTENSION = 'extension',
     ENVIRONMENT = 'environment',
     BACKUP = 'backup',
+    DEBUG = 'debug',
 }
 
 export const RELATE_IS_TESTING = process.env.NODE_ENV === 'test';
@@ -22,6 +23,7 @@ export const DBMS_MANIFEST_FILE = `relate.${ENTITY_TYPES.DBMS}.json`;
 export const PROJECT_MANIFEST_FILE = `relate.${ENTITY_TYPES.PROJECT}.json`;
 export const PROJECT_INSTALL_MANIFEST_FILE = `relate.${ENTITY_TYPES.PROJECT_INSTALL}.json`;
 export const EXTENSION_MANIFEST_FILE = `relate.${ENTITY_TYPES.EXTENSION}.json`;
+export const DEBUG_FILE = `relate.${ENTITY_TYPES.DEBUG}.json`;
 
 export const RELATE_ACCESS_TOKENS_DIR_NAME = 'access-tokens';
 export const DBMS_DIR_NAME = 'dbmss';

--- a/packages/common/src/entities/environments/environment.local.ts
+++ b/packages/common/src/entities/environments/environment.local.ts
@@ -16,6 +16,7 @@ import {
     PLUGIN_SOURCES_DIR_NAME,
     PLUGIN_VERSIONS_DIR_NAME,
     PROJECTS_DIR_NAME,
+    UPGRADE_LOGS_DIR_NAME,
 } from '../../constants';
 import {LocalProjects} from '../projects';
 import {LocalDbs} from '../dbs';
@@ -42,6 +43,7 @@ export class LocalEnvironment extends EnvironmentAbstract {
         ...envPaths(),
         dbmssData: path.join(this.dataPath, DBMS_DIR_NAME),
         backupsData: path.join(this.dataPath, BACKUPS_DIR_NAME),
+        upgradeLogsData: path.join(this.dataPath, UPGRADE_LOGS_DIR_NAME),
         projectsData: path.join(this.dataPath, PROJECTS_DIR_NAME),
         dbmssCache: path.join(this.cachePath, DBMS_DIR_NAME),
         environmentsConfig: path.join(envPaths().config, ENVIRONMENTS_DIR_NAME),

--- a/packages/common/src/utils/dbmss/upgrade-neo4j.ts
+++ b/packages/common/src/utils/dbmss/upgrade-neo4j.ts
@@ -10,7 +10,6 @@ import {emitHookEvent} from '../event-hooks';
 import {dbmsUpgradeConfigs} from './dbms-upgrade-config';
 import {waitForDbmsToBeOnline} from './is-dbms-online';
 import {resolveDbms} from './resolve-dbms';
-import {PropertiesFile} from '../../system/files';
 import {IDbmsInfo, IDbmsUpgradeOptions, PLUGIN_UPGRADE_MODE} from '../../models';
 
 const upgradePlugins = async (
@@ -135,13 +134,13 @@ export const upgradeNeo4j = async (
 
         const dbmsRootPath = env.dbmss.getDbmsRootPath(dbms.id);
         if (dbmsRootPath) {
-            const neo4jConfig = await PropertiesFile.readFile(path.join(dbmsRootPath, NEO4J_CONF_DIR, NEO4J_CONF_FILE));
+            const neo4jConfig = await env.dbmss.getDbmsConfig(dbms.id);
 
             const dateISO = new Date().toISOString();
             const [date] = dateISO.split('.');
             await fse.copy(
                 path.join(dbmsRootPath, neo4jConfig.get('dbms.directories.logs')!),
-                path.join(env.dirPaths.upgradeLogsData, `${kebabCase(dbms.name)}-${date.replaceAll(':', '')}`),
+                path.join(env.dirPaths.upgradeLogsData, `${kebabCase(dbms.name)}-${date.replace(/:/g, '')}`),
             );
         }
 


### PR DESCRIPTION
Adds a new directory in the relate data dir (`upgrade-logs`) that copies the logs from the DBMS failed to upgrade.

### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
A new folder called `upload-logs` is created in the relate storage dir. Whenever an upgrade fails, the logs from the failed upgrade are copied into this directory to help users debug.


### What is the current behavior?
The failed upgrade neo4j directory is just deleted, removing all logs too. Leaving users without the logs for help when debugging.


### What is the new behavior?
Logs of failed upgrades are kept instead of deleted.


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)


### Other information:
