### PR TITLE
Allow stopping DBMSs through shutdown procedure

### DIFF
--- a/packages/cli/docs/dbms.md
+++ b/packages/cli/docs/dbms.md
@@ -249,6 +249,7 @@ ARGUMENTS
 
 OPTIONS
   -e, --environment=environment  Name of the environment to run the command against
+  --shutdown                     Use on Windows to stop the DBMS gracefully (uses the Neo4j shutdown procedure)
 
 EXAMPLES
   $ relate dbms:stop

--- a/packages/cli/docs/dbms.md
+++ b/packages/cli/docs/dbms.md
@@ -249,7 +249,9 @@ ARGUMENTS
 
 OPTIONS
   -e, --environment=environment  Name of the environment to run the command against
-  --shutdown                     Use on Windows to stop the DBMS gracefully (uses the Neo4j shutdown procedure)
+
+  --shutdown                     Use the shutdown procedure, if available, to stop the DBMS (needed on Windows for a
+                                 graceful stop)
 
 EXAMPLES
   $ relate dbms:stop

--- a/packages/cli/src/commands/dbms/stop.ts
+++ b/packages/cli/src/commands/dbms/stop.ts
@@ -1,3 +1,4 @@
+import {flags} from '@oclif/command';
 import BaseCommand from '../../base.command';
 import {ARGS, FLAGS} from '../../constants';
 import {StopModule} from '../../modules/dbms/stop.module';
@@ -22,5 +23,8 @@ export default class StopCommand extends BaseCommand {
 
     static flags = {
         ...FLAGS.ENVIRONMENT,
+        shutdown: flags.boolean({
+            description: 'Use on Windows to stop the DBMS gracefully (uses the Neo4j shutdown procedure)',
+        }),
     };
 }

--- a/packages/cli/src/commands/dbms/stop.ts
+++ b/packages/cli/src/commands/dbms/stop.ts
@@ -24,7 +24,10 @@ export default class StopCommand extends BaseCommand {
     static flags = {
         ...FLAGS.ENVIRONMENT,
         shutdown: flags.boolean({
-            description: 'Use on Windows to stop the DBMS gracefully (uses the Neo4j shutdown procedure)',
+            description:
+                'Use the shutdown procedure, if available, to stop the DBMS (needed on Windows for a graceful stop)',
+            allowNo: process.platform === 'win32',
+            default: process.platform === 'win32',
         }),
     };
 }

--- a/packages/cli/src/modules/dbms/stop.module.ts
+++ b/packages/cli/src/modules/dbms/stop.module.ts
@@ -1,7 +1,7 @@
 import {OnApplicationBootstrap, Module, Inject} from '@nestjs/common';
 import cli from 'cli-ux';
 import {List} from '@relate/types';
-import {SystemModule, SystemProvider, DBMS_STATUS, IDbConnection} from '@relate/common';
+import {SystemModule, SystemProvider, DBMS_STATUS, IQueryTarget} from '@relate/common';
 
 import {readStdinArray, isInteractive} from '../../stdin';
 import StopCommand from '../../commands/dbms/stop';
@@ -23,7 +23,7 @@ export class StopModule implements OnApplicationBootstrap {
     async onApplicationBootstrap(): Promise<void> {
         const {flags} = this.parsed;
         const environment = await this.systemProvider.getEnvironment(flags.environment);
-        let dbmss: string[] | List<IDbConnection> = this.parsed.argv;
+        let dbmss: string[] | List<IQueryTarget> = this.parsed.argv;
 
         if (!dbmss.length) {
             if (isInteractive()) {
@@ -49,7 +49,7 @@ async function getDbConnection(
     systemProvider: SystemProvider,
     environment: EnvironmentAbstract,
     nameOrId: string,
-): Promise<IDbConnection> {
+): Promise<IQueryTarget> {
     const dbms = await environment.dbmss.get(nameOrId);
 
     let accessToken;

--- a/packages/cli/src/modules/dbms/stop.module.ts
+++ b/packages/cli/src/modules/dbms/stop.module.ts
@@ -1,10 +1,12 @@
 import {OnApplicationBootstrap, Module, Inject} from '@nestjs/common';
 import cli from 'cli-ux';
+import {List} from '@relate/types';
+import {SystemModule, SystemProvider, DBMS_STATUS, IDbConnection} from '@relate/common';
 
-import {SystemModule, SystemProvider, DBMS_STATUS} from '@relate/common';
 import {readStdinArray, isInteractive} from '../../stdin';
 import StopCommand from '../../commands/dbms/stop';
-import {selectDbmsPrompt} from '../../prompts';
+import {passwordPrompt, selectDbmsPrompt} from '../../prompts';
+import {EnvironmentAbstract} from '@relate/common/dist/entities/environments';
 
 @Module({
     exports: [],
@@ -21,7 +23,7 @@ export class StopModule implements OnApplicationBootstrap {
     async onApplicationBootstrap(): Promise<void> {
         const {flags} = this.parsed;
         const environment = await this.systemProvider.getEnvironment(flags.environment);
-        let dbmss = this.parsed.argv;
+        let dbmss: string[] | List<IDbConnection> = this.parsed.argv;
 
         if (!dbmss.length) {
             if (isInteractive()) {
@@ -32,7 +34,40 @@ export class StopModule implements OnApplicationBootstrap {
             }
         }
 
+        if (flags.shutdown) {
+            dbmss = await List.from(dbmss)
+                .mapEach((nameOrId) => getDbConnection(this.systemProvider, environment, nameOrId))
+                .unwindPromises();
+        }
+
         cli.action.start('Stopping Neo4j');
         return environment.dbmss.stop(dbmss).then(() => cli.action.stop());
     }
+}
+
+async function getDbConnection(
+    systemProvider: SystemProvider,
+    environment: EnvironmentAbstract,
+    nameOrId: string,
+): Promise<IDbConnection> {
+    const dbms = await environment.dbmss.get(nameOrId);
+
+    let accessToken;
+    try {
+        accessToken = await systemProvider.getAccessToken(environment.id, dbms.id, 'neo4j');
+    } catch {
+        accessToken = await environment.dbmss.createAccessToken('relate', dbms.id, {
+            principal: 'neo4j',
+            credentials: await passwordPrompt(`Enter password for "${dbms.name}"`),
+            scheme: 'basic',
+        });
+
+        await systemProvider.registerAccessToken(environment.id, dbms.id, 'neo4j', accessToken);
+    }
+
+    return {
+        accessToken,
+        dbmsUser: 'neo4j',
+        dbmsNameOrId: dbms.id,
+    };
 }

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -195,6 +195,7 @@ export enum PUBLIC_GRAPHQL_METHODS {
 
 // seconds
 export const MAX_DBMS_TO_BE_ONLINE_ATTEMPTS = 60;
+export const MAX_DBMS_TO_BE_STOPPED_ATTEMPTS = 120;
 
 export const PROJECTS_DIR_NAME = 'projects';
 

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
@@ -178,12 +178,12 @@ describe('LocalDbmsPlugins', () => {
         });
 
         const [res] = await dbReadQuery(
+            app.environment,
             {
                 database: 'neo4j',
                 dbmsUser: 'neo4j',
                 accessToken,
-                dbmsId: dbms.id,
-                environment: app.environment,
+                dbmsNameOrId: dbms.id,
             },
             'RETURN apoc.version() AS apocVersion',
         ).finally(() => app.environment.dbmss.stop([dbms.id]));

--- a/packages/common/src/entities/dbmss/dbmss.abstract.ts
+++ b/packages/common/src/entities/dbmss/dbmss.abstract.ts
@@ -4,7 +4,7 @@ import {driver, Driver, QueryResult} from 'neo4j-driver-lite';
 import {
     DbmsManifestModel,
     IAuthToken,
-    IDbConnection,
+    IQueryTarget,
     IDbms,
     IDbmsInfo,
     IDbmsUpgradeOptions,
@@ -101,7 +101,7 @@ export abstract class DbmssAbstract<Env extends EnvironmentAbstract> {
      * Stop one or more DBMSs
      * @param   dbmsIds
      */
-    abstract stop(dbmsIds: Array<string | IDbConnection> | List<string | IDbConnection>): Promise<List<string>>;
+    abstract stop(dbmsIds: Array<string | IQueryTarget> | List<string | IQueryTarget>): Promise<List<string>>;
 
     /**
      * Get info for one or more DBMSs

--- a/packages/common/src/entities/dbmss/dbmss.abstract.ts
+++ b/packages/common/src/entities/dbmss/dbmss.abstract.ts
@@ -1,7 +1,15 @@
 import {List} from '@relate/types';
 import {driver, Driver, QueryResult} from 'neo4j-driver-lite';
 
-import {DbmsManifestModel, IAuthToken, IDbms, IDbmsInfo, IDbmsUpgradeOptions, IDbmsVersion} from '../../models';
+import {
+    DbmsManifestModel,
+    IAuthToken,
+    IDbConnection,
+    IDbms,
+    IDbmsInfo,
+    IDbmsUpgradeOptions,
+    IDbmsVersion,
+} from '../../models';
 
 import {EnvironmentAbstract, NEO4J_EDITION} from '../environments';
 import {PropertiesFile} from '../../system/files';
@@ -93,7 +101,7 @@ export abstract class DbmssAbstract<Env extends EnvironmentAbstract> {
      * Stop one or more DBMSs
      * @param   dbmsIds
      */
-    abstract stop(dbmsIds: string[] | List<string>): Promise<List<string>>;
+    abstract stop(dbmsIds: Array<string | IDbConnection> | List<string | IDbConnection>): Promise<List<string>>;
 
     /**
      * Get info for one or more DBMSs

--- a/packages/common/src/entities/dbmss/dbmss.local.ts
+++ b/packages/common/src/entities/dbmss/dbmss.local.ts
@@ -13,7 +13,7 @@ import {
     DbmsManifestModel,
     IDbmsUpgradeOptions,
     IAuthToken,
-    IDbConnection,
+    IQueryTarget,
 } from '../../models';
 import {
     discoverNeo4jDistributions,
@@ -300,7 +300,7 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
             .unwindPromises();
     }
 
-    stop(nameOrIds: Array<string | IDbConnection> | List<string | IDbConnection>): Promise<List<string>> {
+    stop(nameOrIds: Array<string | IQueryTarget> | List<string | IQueryTarget>): Promise<List<string>> {
         return List.from(nameOrIds)
             .mapEach(async (nameOrId) => {
                 if (typeof nameOrId === 'string') {

--- a/packages/common/src/entities/dbmss/dbmss.remote.ts
+++ b/packages/common/src/entities/dbmss/dbmss.remote.ts
@@ -1,7 +1,15 @@
 import gql from 'graphql-tag';
 import {List} from '@relate/types';
 
-import {IDbms, IDbmsInfo, IDbmsVersion, DbmsManifestModel, IDbmsUpgradeOptions, IAuthToken} from '../../models';
+import {
+    IDbms,
+    IDbmsInfo,
+    IDbmsVersion,
+    DbmsManifestModel,
+    IDbmsUpgradeOptions,
+    IAuthToken,
+    IDbConnection,
+} from '../../models';
 
 import {DbmssAbstract} from './dbmss.abstract';
 import {NEO4J_EDITION, RemoteEnvironment} from '../environments';
@@ -279,7 +287,7 @@ export class RemoteDbmss extends DbmssAbstract<RemoteEnvironment> {
         return List.from(data[PUBLIC_GRAPHQL_METHODS.START_DBMSS]);
     }
 
-    async stop(namesOrIds: string[]): Promise<List<string>> {
+    async stop(namesOrIds: Array<string | IDbConnection> | List<string | IDbConnection>): Promise<List<string>> {
         const {data, errors}: any = await this.environment.graphql({
             query: gql`
                 mutation StopDBMSSs($environmentId: String, $namesOrIds: [String!]!) {

--- a/packages/common/src/entities/dbmss/dbmss.remote.ts
+++ b/packages/common/src/entities/dbmss/dbmss.remote.ts
@@ -8,7 +8,7 @@ import {
     DbmsManifestModel,
     IDbmsUpgradeOptions,
     IAuthToken,
-    IDbConnection,
+    IQueryTarget,
 } from '../../models';
 
 import {DbmssAbstract} from './dbmss.abstract';
@@ -287,7 +287,7 @@ export class RemoteDbmss extends DbmssAbstract<RemoteEnvironment> {
         return List.from(data[PUBLIC_GRAPHQL_METHODS.START_DBMSS]);
     }
 
-    async stop(namesOrIds: Array<string | IDbConnection> | List<string | IDbConnection>): Promise<List<string>> {
+    async stop(namesOrIds: Array<string | IQueryTarget> | List<string | IQueryTarget>): Promise<List<string>> {
         const {data, errors}: any = await this.environment.graphql({
             query: gql`
                 mutation StopDBMSSs($environmentId: String, $namesOrIds: [String!]!) {

--- a/packages/common/src/entities/dbs/dbs.local.ts
+++ b/packages/common/src/entities/dbs/dbs.local.ts
@@ -12,51 +12,48 @@ import {cypherShellCmd} from '../../utils/dbmss/cypher-shell';
 import {DbsAbstract} from './dbs.abstract';
 
 export class LocalDbs extends DbsAbstract<LocalEnvironment> {
-    async create(nameOrId: string, dbmsUser: string, dbName: string, accessToken: string): Promise<void> {
-        const dbms = await this.environment.dbmss.get(nameOrId);
+    async create(dbmsNameOrId: string, dbmsUser: string, dbName: string, accessToken: string): Promise<void> {
         if (!dbName.match(NEO4J_DB_NAME_REGEX)) {
             throw new CypherParameterError(`Cannot safely pass "${dbName}" as a Cypher parameter`);
         }
 
         await dbWriteQuery(
+            this.environment,
             {
                 database: 'system',
                 accessToken,
-                dbmsId: dbms.id,
+                dbmsNameOrId,
                 dbmsUser,
-                environment: this.environment,
             },
             `CREATE DATABASE ${dbName}`,
         );
     }
 
-    async drop(nameOrId: string, dbmsUser: string, dbName: string, accessToken: string): Promise<void> {
-        const dbms = await this.environment.dbmss.get(nameOrId);
+    async drop(dbmsNameOrId: string, dbmsUser: string, dbName: string, accessToken: string): Promise<void> {
         if (!dbName.match(NEO4J_DB_NAME_REGEX)) {
             throw new CypherParameterError(`Cannot safely pass "${dbName}" as a Cypher parameter`);
         }
 
         await dbWriteQuery(
+            this.environment,
             {
                 database: 'system',
                 accessToken,
-                dbmsId: dbms.id,
+                dbmsNameOrId,
                 dbmsUser,
-                environment: this.environment,
             },
             `DROP DATABASE ${dbName}`,
         );
     }
 
-    async list(nameOrId: string, dbmsUser: string, accessToken: string): Promise<List<IDb>> {
-        const dbms = await this.environment.dbmss.get(nameOrId);
+    async list(dbmsNameOrId: string, dbmsUser: string, accessToken: string): Promise<List<IDb>> {
         const dbs = await dbReadQuery(
+            this.environment,
             {
                 database: 'system',
                 accessToken,
-                dbmsId: dbms.id,
+                dbmsNameOrId,
                 dbmsUser,
-                environment: this.environment,
             },
             `SHOW DATABASES`,
         );

--- a/packages/common/src/models/dbms.model.ts
+++ b/packages/common/src/models/dbms.model.ts
@@ -1,7 +1,11 @@
+import {IsOptional, IsString} from 'class-validator';
+
 import {PropertiesFile} from '../system/files';
 import {DBMS_STATUS, DBMS_SERVER_STATUS} from '../constants';
 import {NEO4J_EDITION, NEO4J_ORIGIN} from '../entities/environments';
 import {ManifestModel, IManifest} from './manifest.model';
+import {IsValidJWT} from './custom-validators';
+import {ModelAbstract} from './model.abstract';
 
 export interface IDb {
     name: string;
@@ -10,6 +14,13 @@ export interface IDb {
     currentStatus: string;
     error: string;
     default: boolean;
+}
+
+export interface IDbConnection {
+    dbmsNameOrId: string;
+    dbmsUser: string;
+    accessToken: string;
+    dbName?: string;
 }
 
 export interface IDbmsInfo extends Omit<IDbms, 'config'> {
@@ -48,3 +59,18 @@ export interface IDbms extends IManifest {
 }
 
 export class DbmsManifestModel extends ManifestModel<IManifest> implements IManifest {}
+
+export class DbConnectionModel extends ModelAbstract<IDbConnection> {
+    @IsString()
+    public dbmsNameOrId!: string;
+
+    @IsString()
+    public dbmsUser!: string;
+
+    @IsValidJWT()
+    public accessToken!: string;
+
+    @IsOptional()
+    @IsString()
+    public dbName?: string;
+}

--- a/packages/common/src/models/dbms.model.ts
+++ b/packages/common/src/models/dbms.model.ts
@@ -16,11 +16,11 @@ export interface IDb {
     default: boolean;
 }
 
-export interface IDbConnection {
+export interface IQueryTarget {
     dbmsNameOrId: string;
     dbmsUser: string;
     accessToken: string;
-    dbName?: string;
+    database?: string;
 }
 
 export interface IDbmsInfo extends Omit<IDbms, 'config'> {
@@ -60,7 +60,7 @@ export interface IDbms extends IManifest {
 
 export class DbmsManifestModel extends ManifestModel<IManifest> implements IManifest {}
 
-export class DbConnectionModel extends ModelAbstract<IDbConnection> {
+export class QueryTargetModel extends ModelAbstract<IQueryTarget> {
     @IsString()
     public dbmsNameOrId!: string;
 
@@ -72,5 +72,5 @@ export class DbConnectionModel extends ModelAbstract<IDbConnection> {
 
     @IsOptional()
     @IsString()
-    public dbName?: string;
+    public database?: string;
 }

--- a/packages/common/src/utils/dbmss/dbms-stop.ts
+++ b/packages/common/src/utils/dbmss/dbms-stop.ts
@@ -1,6 +1,6 @@
 import {DBMS_SERVER_STATUS, DBMS_STATUS, HOOK_EVENTS} from '../../constants';
 import {LocalEnvironment} from '../../entities/environments';
-import {DbConnectionModel, IDbConnection} from '../../models';
+import {QueryTargetModel, IQueryTarget} from '../../models';
 import {emitHookEvent} from '../event-hooks';
 import {waitForDbmsToStop} from './is-dbms-online';
 import {neo4jCmd} from './neo4j-cmd';
@@ -16,8 +16,8 @@ export async function signalStop(environment: LocalEnvironment, nameOrId: string
     return neo4jCmd(environment.dbmss.getDbmsRootPath(id), 'stop');
 }
 
-export async function procedureStop(environment: LocalEnvironment, dbConnection: IDbConnection): Promise<void> {
-    const conn = new DbConnectionModel(dbConnection);
+export async function procedureStop(environment: LocalEnvironment, dbConnection: IQueryTarget): Promise<void> {
+    const conn = new QueryTargetModel(dbConnection);
     const dbms = await environment.dbmss.get(conn.dbmsNameOrId, true);
 
     if (dbms.status === DBMS_STATUS.STOPPED) {

--- a/packages/common/src/utils/dbmss/dbms-stop.ts
+++ b/packages/common/src/utils/dbmss/dbms-stop.ts
@@ -1,0 +1,69 @@
+import {DBMS_SERVER_STATUS, HOOK_EVENTS} from '../../constants';
+import {LocalEnvironment} from '../../entities/environments';
+import {DbConnectionModel, IDbConnection} from '../../models';
+import {emitHookEvent} from '../event-hooks';
+import {waitForDbmsToStop} from './is-dbms-online';
+import {neo4jCmd} from './neo4j-cmd';
+import {winNeo4jStop} from './neo4j-process-win';
+
+export async function signalStop(environment: LocalEnvironment, nameOrId: string): Promise<string> {
+    const {id} = await environment.dbmss.getDbms(nameOrId);
+
+    if (process.platform === 'win32') {
+        return winNeo4jStop(environment.dbmss.getDbmsRootPath(id));
+    }
+
+    return neo4jCmd(environment.dbmss.getDbmsRootPath(id), 'stop');
+}
+
+export async function procedureStop(environment: LocalEnvironment, dbConnection: IDbConnection): Promise<void> {
+    const conn = new DbConnectionModel(dbConnection);
+    const dbms = await environment.dbmss.get(conn.dbmsNameOrId, true);
+
+    if (dbms.serverStatus !== DBMS_SERVER_STATUS.ONLINE) {
+        return;
+    }
+
+    const driver = await environment.dbmss.getDriverInstance(dbms.id, {
+        credentials: conn.accessToken,
+        principal: conn.dbmsUser,
+        scheme: 'basic',
+    });
+
+    const session = driver.session();
+
+    // Not awaiting this session on purpose as when it runs correctly the DBMS
+    // will shut down before we can get any response (leading to a timeout of
+    // the driver).
+    session.run('CALL unsupported.dbms.shutdown()').catch(async (error) => {
+        const message = error.message || '';
+
+        if (message.includes('No routing servers available') || message.includes('Connection was closed by server')) {
+            // The call worked as intended and either the DBMS is stopped and
+            // the driver timed out, or we closed the connection because we
+            // detected that the DBMS is stopped.
+            return;
+        }
+
+        if (message.includes('There is no procedure with the name `unsupported.dbms.shutdown`')) {
+            await emitHookEvent(
+                HOOK_EVENTS.DEBUG,
+                `DBMS "${dbms.id}" does not support the shutdown procedure, falling back to signal stop`,
+            );
+            await signalStop(environment, dbms.id);
+            return;
+        }
+
+        await emitHookEvent(
+            HOOK_EVENTS.DEBUG,
+            `Error while calling the shutdown procedure on "${dbms.id}", falling back to signal stop: \n${message}`,
+        );
+        await signalStop(environment, dbms.id);
+    });
+
+    await waitForDbmsToStop(environment, dbms.id);
+
+    // The driver needs to be closed to avoid blocking the Relate process with
+    // the potentially open session/request.
+    await driver.close();
+}

--- a/packages/common/src/utils/dbmss/system-db-query.ts
+++ b/packages/common/src/utils/dbmss/system-db-query.ts
@@ -4,20 +4,18 @@ import {Record} from 'neo4j-driver-lite';
 import {NotFoundError, NotAllowedError, DbmsQueryError} from '../../errors';
 import {EnvironmentAbstract} from '../../entities/environments';
 import {DBMS_STATUS} from '../../constants';
+import {IQueryTarget} from '../../models';
 
-export interface IQueryTarget {
-    database?: string;
-    environment: EnvironmentAbstract;
-    dbmsId: string;
-    dbmsUser: string;
-    accessToken: string;
-}
+export const dbReadQuery = async (
+    environment: EnvironmentAbstract,
+    target: IQueryTarget,
+    query: string,
+    params: any = {},
+): Promise<List<Record>> => {
+    const {dbmss} = environment;
 
-export const dbReadQuery = async (target: IQueryTarget, query: string, params: any = {}): Promise<List<Record>> => {
-    const {dbmss} = target.environment;
-
-    const dbmsInfo = (await dbmss.info([target.dbmsId])).first.getOrElse(() => {
-        throw new NotFoundError(`DBMS ${target.dbmsId} not found`);
+    const dbmsInfo = (await dbmss.info([target.dbmsNameOrId])).first.getOrElse(() => {
+        throw new NotFoundError(`DBMS ${target.dbmsNameOrId} not found`);
     });
 
     if (dbmsInfo.status === DBMS_STATUS.STOPPED) {
@@ -41,11 +39,16 @@ export const dbReadQuery = async (target: IQueryTarget, query: string, params: a
     }
 };
 
-export const dbWriteQuery = async (target: IQueryTarget, query: string, params: any = {}): Promise<List<Record>> => {
-    const {dbmss} = target.environment;
+export const dbWriteQuery = async (
+    environment: EnvironmentAbstract,
+    target: IQueryTarget,
+    query: string,
+    params: any = {},
+): Promise<List<Record>> => {
+    const {dbmss} = environment;
 
-    const dbmsInfo = (await dbmss.info([target.dbmsId])).first.getOrElse(() => {
-        throw new NotFoundError(`DBMS ${target.dbmsId} not found`);
+    const dbmsInfo = (await dbmss.info([target.dbmsNameOrId])).first.getOrElse(() => {
+        throw new NotFoundError(`DBMS ${target.dbmsNameOrId} not found`);
     });
 
     if (dbmsInfo.status === DBMS_STATUS.STOPPED) {

--- a/scripts/tests/setup.js
+++ b/scripts/tests/setup.js
@@ -4,7 +4,14 @@ const fse = require('fs-extra');
 const ora = require('ora');
 
 const envSetup = require('../../e2e/jest-global.setup');
-const {TestDbmss, envPaths, download, PropertiesFile, downloadJava} = require('../../packages/common');
+const {
+    TestDbmss,
+    envPaths,
+    download,
+    PropertiesFile,
+    resolveRelateJavaHome,
+    downloadJava,
+} = require('../../packages/common');
 const {List} = require('../../packages/types');
 
 envSetup();
@@ -31,14 +38,16 @@ async function setupApoc(dbmsRootPath) {
 async function populateDistributionCache(env) {
     const versions = List.of([TestDbmss.NEO4J_VERSION, '3.5.19', '4.0.5', '4.0.6', '4.1.0']);
 
-    const spinner = ora('Downloading Java').start();
-    try {
-        await downloadJava('4.0.0');
-    } catch (err) {
-        spinner.fail();
-        throw err;
+    if (!(await resolveRelateJavaHome('4.0.0'))) {
+        const spinner = ora('Downloading Java').start();
+        try {
+            await downloadJava('4.0.0');
+        } catch (err) {
+            spinner.fail();
+            throw err;
+        }
+        spinner.succeed();
     }
-    spinner.succeed();
 
     // Running the installations in sequence to avoid hogging resources
     // (we're decompressing archives during the installation).

--- a/scripts/tests/teardown.js
+++ b/scripts/tests/teardown.js
@@ -20,9 +20,8 @@ async function globalTeardown() {
         .catch((err) => console.error(err));
 
     const cacheFiles = List.from(await fse.readdir(env.cachePath))
-        .filter((filename) => !['.GITIGNORED', 'dbmss'].includes(filename))
+        .filter((filename) => !['.GITIGNORED', 'dbmss', 'runtime'].includes(filename))
         .mapEach((filename) => path.join(env.cachePath, filename));
-
 
     const dbmssPath = path.join(env.dataPath, DBMS_DIR_NAME);
     try {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Feature


### What is the current behavior?
DBMSs are stopped only through the Neo4j scripts or in the case of Windows they are forcefully terminated.


### What is the new behavior?
DBMSs can now be stopped through the shutdown procedure by passing the connection details to the stop function instead of the name or ID of the DBMSs. This will allow gracefully stopping the DBMS on Windows.


### Does this PR introduce a breaking change?
No


### Other information:
