### PR TITLE
neo4j-driver-lite 4.3 official release driver bump

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@relate/common",
-            "version": "1.0.3-alpha.0",
+            "version": "1.0.3-alpha.1",
             "license": "GPL-3.0",
             "dependencies": {
                 "@neo4j/code-signer": "1.1.3",
@@ -22,7 +22,7 @@
                 "hasha": "5.2.0",
                 "jsonwebtoken": "8.5.1",
                 "jszip": "3.5.0",
-                "neo4j-driver-lite": "4.3.0-rc02",
+                "neo4j-driver-lite": "4.3.0",
                 "node-forge": "0.10.0",
                 "p-limit": "3.1.0",
                 "rxjs": "6.5.5",
@@ -36,7 +36,7 @@
                 "@nestjs/config": "0.4.0",
                 "@nestjs/core": "7.0.8",
                 "@nestjs/testing": "7.0.8",
-                "@relate/types": "^1.0.3-alpha.0",
+                "@relate/types": "^1.0.3-alpha.1",
                 "@types/decompress": "4.2.3",
                 "@types/fs-extra": "9.0.10",
                 "@types/got": "9.6.10",
@@ -1794,9 +1794,9 @@
             }
         },
         "node_modules/@relate/types": {
-            "version": "1.0.3-alpha.0",
-            "resolved": "https://registry.npmjs.org/@relate/types/-/types-1.0.3-alpha.0.tgz",
-            "integrity": "sha512-MaLKn39iMQa9DaPHiiBm1ExrxveZKc6RhUxTitxgCTrBv7LzL3AzMa7YaupzkBoP0a7hB/brHwL91oZf2eRsbA==",
+            "version": "1.0.3-alpha.1",
+            "resolved": "https://registry.npmjs.org/@relate/types/-/types-1.0.3-alpha.1.tgz",
+            "integrity": "sha512-0LAHjRskY5Rm+We/vmmGRgJ7NCZdiJivIZmzePJnv2tGV+yOGcF+GMdrPVg88nIvVCv1MdxdO8uWKT82CKoBeA==",
             "dev": true,
             "dependencies": {
                 "lodash": "4.17.21"
@@ -9062,26 +9062,27 @@
             "dev": true
         },
         "node_modules/neo4j-driver-bolt-connection": {
-            "version": "4.3.0-rc02",
-            "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.3.0-rc02.tgz",
-            "integrity": "sha512-Q2om1NeECmSWCGYM32UidYhd0iBQOZRvcMQfnefUaMAeIvPB0aIZ8s8CNebW+lwM3zgx2vCsD5O6qGFDezP+NA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.3.0.tgz",
+            "integrity": "sha512-MTzixvHoZNmYbWgUeggXFUhgetr5BlVZ9hY5pWCnkttoTwS21D/ygs+oDyn3tJKvNd8INRsrwKh4dG3izvp2Xg==",
             "dependencies": {
-                "neo4j-driver-core": "^4.3.0-rc02",
+                "neo4j-driver-core": "^4.3.0",
                 "text-encoding-utf-8": "^1.0.2"
             }
         },
         "node_modules/neo4j-driver-core": {
-            "version": "4.3.0-rc02",
-            "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-4.3.0-rc02.tgz",
-            "integrity": "sha512-rt7myj7N6TZ+q1Y4eCyx+kHf43XKXDigjgeMcg1lT6upmvDUhiS2QsEUXR3LwvhInKxSXSyDRHBP6CVEDcvl+w=="
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-4.3.0.tgz",
+            "integrity": "sha512-XJULrmfeTtDKonchufDqTpf5qQ93RI5vbyOxZ/S4VospfKGeWsl6KmwXvp3fY1nCKWTny/Ekm4hw1vod2XyZEA=="
         },
         "node_modules/neo4j-driver-lite": {
-            "version": "4.3.0-rc02",
-            "resolved": "https://registry.npmjs.org/neo4j-driver-lite/-/neo4j-driver-lite-4.3.0-rc02.tgz",
-            "integrity": "sha512-GEFDL9qAMUIb9PHexYhXk8F8UdvFeBUvHA5UPXMMib1OBHpcoF7i0STvpipAzxOsTTPgATt+vStBlUqh/kgIlA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/neo4j-driver-lite/-/neo4j-driver-lite-4.3.0.tgz",
+            "integrity": "sha512-yPRBMRHifBE1p/BUVGI1sh6Xe6+yylIjItY7Lh4FLRcPka0BQ7ENSFHk1Wefdunh16/WVBSf37+2NAPbFEgKDA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "neo4j-driver-bolt-connection": "^4.3.0-rc02",
-                "neo4j-driver-core": "^4.3.0-rc02"
+                "neo4j-driver-bolt-connection": "^4.3.0",
+                "neo4j-driver-core": "^4.3.0"
             }
         },
         "node_modules/nice-try": {
@@ -13388,9 +13389,9 @@
             }
         },
         "@relate/types": {
-            "version": "1.0.3-alpha.0",
-            "resolved": "https://registry.npmjs.org/@relate/types/-/types-1.0.3-alpha.0.tgz",
-            "integrity": "sha512-MaLKn39iMQa9DaPHiiBm1ExrxveZKc6RhUxTitxgCTrBv7LzL3AzMa7YaupzkBoP0a7hB/brHwL91oZf2eRsbA==",
+            "version": "1.0.3-alpha.1",
+            "resolved": "https://registry.npmjs.org/@relate/types/-/types-1.0.3-alpha.1.tgz",
+            "integrity": "sha512-0LAHjRskY5Rm+We/vmmGRgJ7NCZdiJivIZmzePJnv2tGV+yOGcF+GMdrPVg88nIvVCv1MdxdO8uWKT82CKoBeA==",
             "dev": true,
             "requires": {
                 "lodash": "4.17.21"
@@ -19377,26 +19378,26 @@
             "dev": true
         },
         "neo4j-driver-bolt-connection": {
-            "version": "4.3.0-rc02",
-            "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.3.0-rc02.tgz",
-            "integrity": "sha512-Q2om1NeECmSWCGYM32UidYhd0iBQOZRvcMQfnefUaMAeIvPB0aIZ8s8CNebW+lwM3zgx2vCsD5O6qGFDezP+NA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.3.0.tgz",
+            "integrity": "sha512-MTzixvHoZNmYbWgUeggXFUhgetr5BlVZ9hY5pWCnkttoTwS21D/ygs+oDyn3tJKvNd8INRsrwKh4dG3izvp2Xg==",
             "requires": {
-                "neo4j-driver-core": "^4.3.0-rc02",
+                "neo4j-driver-core": "^4.3.0",
                 "text-encoding-utf-8": "^1.0.2"
             }
         },
         "neo4j-driver-core": {
-            "version": "4.3.0-rc02",
-            "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-4.3.0-rc02.tgz",
-            "integrity": "sha512-rt7myj7N6TZ+q1Y4eCyx+kHf43XKXDigjgeMcg1lT6upmvDUhiS2QsEUXR3LwvhInKxSXSyDRHBP6CVEDcvl+w=="
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-4.3.0.tgz",
+            "integrity": "sha512-XJULrmfeTtDKonchufDqTpf5qQ93RI5vbyOxZ/S4VospfKGeWsl6KmwXvp3fY1nCKWTny/Ekm4hw1vod2XyZEA=="
         },
         "neo4j-driver-lite": {
-            "version": "4.3.0-rc02",
-            "resolved": "https://registry.npmjs.org/neo4j-driver-lite/-/neo4j-driver-lite-4.3.0-rc02.tgz",
-            "integrity": "sha512-GEFDL9qAMUIb9PHexYhXk8F8UdvFeBUvHA5UPXMMib1OBHpcoF7i0STvpipAzxOsTTPgATt+vStBlUqh/kgIlA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/neo4j-driver-lite/-/neo4j-driver-lite-4.3.0.tgz",
+            "integrity": "sha512-yPRBMRHifBE1p/BUVGI1sh6Xe6+yylIjItY7Lh4FLRcPka0BQ7ENSFHk1Wefdunh16/WVBSf37+2NAPbFEgKDA==",
             "requires": {
-                "neo4j-driver-bolt-connection": "^4.3.0-rc02",
-                "neo4j-driver-core": "^4.3.0-rc02"
+                "neo4j-driver-bolt-connection": "^4.3.0",
+                "neo4j-driver-core": "^4.3.0"
             }
         },
         "nice-try": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -79,7 +79,7 @@
         "hasha": "5.2.0",
         "jsonwebtoken": "8.5.1",
         "jszip": "3.5.0",
-        "neo4j-driver-lite": "4.3.0-rc02",
+        "neo4j-driver-lite": "4.3.0",
         "node-forge": "0.10.0",
         "p-limit": "3.1.0",
         "rxjs": "6.5.5",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Similar to https://github.com/neo4j-devtools/relate/pull/285

Updated to official release of neo4j-driver-lite


### What is the current behavior?
Not much different to `rc` version used currently


### What is the new behavior?
Same as before


### Does this PR introduce a breaking change?
No


### Other information:
Tested for 4.2.x and 4.3 DBMSs - works as expected. Tested with 3.5.17 and thats fails as expected (for access-token and db operations)
