### PR TITLE
Allow installing prerelease versions of the DBMS

### DIFF
--- a/packages/cli/src/modules/dbms/info.module.ts
+++ b/packages/cli/src/modules/dbms/info.module.ts
@@ -39,6 +39,9 @@ export class InfoModule implements OnApplicationBootstrap {
                 name: {},
                 version: {},
                 edition: {},
+                prerelease: {
+                    extended: true,
+                },
                 status: {},
                 serverStatus: {
                     header: 'Server status',

--- a/packages/common/src/entities/dbmss/dbmss.local.ts
+++ b/packages/common/src/entities/dbmss/dbmss.local.ts
@@ -358,6 +358,7 @@ export class LocalDbmss extends DbmssAbstract<LocalEnvironment> {
                     status,
                     serverStatus,
                     version: v?.version,
+                    prerelease: v?.prerelease,
                 };
             })
             .unwindPromises();

--- a/packages/common/src/models/dbms.model.ts
+++ b/packages/common/src/models/dbms.model.ts
@@ -29,11 +29,13 @@ export interface IDbmsInfo extends Omit<IDbms, 'config'> {
     config?: null | undefined;
     edition?: NEO4J_EDITION;
     version?: string;
+    prerelease?: string;
 }
 
 export interface IDbmsVersion {
     edition: NEO4J_EDITION;
     version: string;
+    prerelease?: string;
     dist: string;
     origin: NEO4J_ORIGIN;
 }

--- a/packages/common/src/utils/dbmss/cypher-shell.ts
+++ b/packages/common/src/utils/dbmss/cypher-shell.ts
@@ -39,7 +39,7 @@ export async function cypherShellCmd(
     credentials?: string,
 ): Promise<string> {
     const cypherShellBinPath = path.join(dbmsRootPath, NEO4J_BIN_DIR, CYPHER_SHELL_BIN_FILE);
-    const dbmsVersion = await getDistributionVersion(dbmsRootPath);
+    const {version: dbmsVersion} = await getDistributionVersion(dbmsRootPath);
     const relateJavaHome = await resolveRelateJavaHome(dbmsVersion);
 
     let stream;

--- a/packages/common/src/utils/dbmss/neo4j-admin-cmd.ts
+++ b/packages/common/src/utils/dbmss/neo4j-admin-cmd.ts
@@ -15,7 +15,7 @@ export async function neo4jAdminCmd(
     javaPath?: string,
 ): Promise<string> {
     const neo4jAdminBinPath = path.join(dbmsRootPath, NEO4J_BIN_DIR, NEO4J_ADMIN_BIN_FILE);
-    const dbmsVersion = await getDistributionVersion(dbmsRootPath);
+    const {version: dbmsVersion} = await getDistributionVersion(dbmsRootPath);
     const relateJavaHome = javaPath || (await resolveRelateJavaHome(dbmsVersion));
 
     await fse.access(neo4jAdminBinPath, fse.constants.X_OK).catch(() => {

--- a/packages/common/src/utils/dbmss/neo4j-cmd.ts
+++ b/packages/common/src/utils/dbmss/neo4j-cmd.ts
@@ -10,7 +10,7 @@ import {getDistributionVersion} from './dbms-versions';
 
 export async function neo4jCmd(dbmsRootPath: string, command: string): Promise<string> {
     const neo4jBinPath = path.join(dbmsRootPath, NEO4J_BIN_DIR, NEO4J_BIN_FILE);
-    const dbmsVersion = await getDistributionVersion(dbmsRootPath);
+    const {version: dbmsVersion} = await getDistributionVersion(dbmsRootPath);
     const relateJavaHome = await resolveRelateJavaHome(dbmsVersion);
 
     await fse.access(neo4jBinPath, fse.constants.X_OK).catch(() => {

--- a/packages/common/src/utils/dbmss/neo4j-process-win.ts
+++ b/packages/common/src/utils/dbmss/neo4j-process-win.ts
@@ -45,7 +45,7 @@ export const winNeo4jStart = async (dbmsRoot: string): Promise<string> => {
         return 'neo4j already running';
     }
 
-    const dbmsVersion = await getDistributionVersion(dbmsRoot);
+    const {version: dbmsVersion} = await getDistributionVersion(dbmsRoot);
     const relateJavaHome = await resolveRelateJavaHome(dbmsVersion);
 
     const env = new EnvVars({cloneFromProcess: true});

--- a/packages/web/src/entities/dbms/dbms.types.ts
+++ b/packages/web/src/entities/dbms/dbms.types.ts
@@ -39,6 +39,9 @@ export class DbmsInfo extends Dbms {
 
     @Field(() => String, {nullable: true})
     edition?: string;
+
+    @Field(() => String, {nullable: true})
+    prerelease?: string;
 }
 
 @ArgsType()


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix


### What is the current behavior?
It's not possible to install Neo4j distributions that contain a prerelease label in the version (eg. `4.3.0-preview`).


### What is the new behavior?
It's now possible to install prerelease versions of Neo4j, and the DBMS info now contains a new optional attribute containing that prerelease label.


### Does this PR introduce a breaking change?
No


### Other information:
To try this, download the 4.3.0-preview archive from [here](https://neo4j.com/download-center/#enterprise) and then run:
```
relate dbms:install ./neo4j-enterprise-4.3.0-preview-[platform].tar --name 43preview
```
Or after extracting the archive:
```
relate dbms:link ./neo4j-enterprise-4.3.0-preview 43preview
```