### PR TITLE
Escape arguments properly on Windows DBMS scripts 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4703,9 +4703,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -7069,9 +7069,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.0.1.tgz",
+      "integrity": "sha512-VU4pzAuh7Kip71XEmO9aNREYAdMHFGTVj/i+CaTImS8x0i1d3jUZkXhqluy/PRgjPLMgsLQulYY3PJ/aSbSjpQ==",
       "dev": true
     },
     "npm-bundled": {
@@ -7792,13 +7792,13 @@
       }
     },
     "parse-url": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.2.tgz",
-      "integrity": "sha512-Czj+GIit4cdWtxo3ISZCvLiUjErSo0iI3wJ+q9Oi3QuMYTI6OZu+7cewMWZ+C1YAnKhYTk6/TLuhIgCypLthPA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.3.tgz",
+      "integrity": "sha512-nrLCVMJpqo12X8uUJT4GJPd5AFaTOrGx/QpJy3HNcVtq0AZSstVIsnxS5fqNPuoqMUs3MyfBoOP6Zvu2Arok5A==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
-        "normalize-url": "^3.3.0",
+        "normalize-url": "^6.0.1",
         "parse-path": "^4.0.0",
         "protocols": "^1.4.0"
       }
@@ -9109,9 +9109,9 @@
       "dev": true
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "trim-off-newlines": {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,7 @@
         "prepare": "run-s lerna:clean lerna:bootstrap",
         "generate:licenses": "node scripts/licenses/index.js",
         "generate:docs": "lerna run generate:docs",
-        "watch": "lerna run watch --stream --parallel",
-        "fix:locks": "lerna exec \"npm install --ignore-scripts --no-audit\"",
-        "add:locks": "git add packages/*/package-lock.json",
-        "version": "run-s lerna:clean fix:locks add:locks"
+        "watch": "lerna run watch --stream --parallel"
     },
     "devDependencies": {
         "@types/node-fetch": "2.5.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -119,11 +119,13 @@
         "build:clean": "run-s clean build:tsc",
         "build:tsc": "tsc -b",
         "build:manifest": "node -e '' | npm run dev-cli -- manifest",
-        "generate:docs": "npm run dev-cli -- readme --multi --dir=./docs",
         "clean": "rimraf dist",
         "test": "jest",
+        "generate:docs": "npm run dev-cli -- readme --multi --dir=./docs",
         "add:docs": "git add README.md docs",
-        "version": "run-s generate:docs add:docs",
+        "fix:locks": "npm install --ignore-scripts --no-audit",
+        "add:locks": "git add package-lock.json",
+        "version": "run-s generate:docs add:docs fix:locks add:locks",
         "watch": "tsc -w"
     }
 }

--- a/packages/cli/src/modules/db/dump.module.ts
+++ b/packages/cli/src/modules/db/dump.module.ts
@@ -53,27 +53,8 @@ export class DumpModule implements OnApplicationBootstrap {
 
         cli.action.start(`Dumping ${database} from ${dbms.name}`);
         return environment.dbs.dump(dbms.id, database, filePath).then((res: string) => {
-            let result = chalk.green('done');
-
-            const message = ['------------------------------------------'];
-            if (res.search(/Done: (\d*) files, (.*) processed./) !== -1) {
-                const done = res.split('\n').reverse();
-                message.push(chalk.green(done[1]));
-                message.push(
-                    `Successfully dumped ${chalk.cyan(database)} ` +
-                        `from ${chalk.cyan(dbms.name)} to ${chalk.cyan(filePath)}`,
-                );
-            } else {
-                result = chalk.red('failed');
-                if (res.includes('Database does not exist')) {
-                    message.push(`Database does not exist: ${chalk.cyan(database)}`);
-                }
-                message.push(chalk.red(`Failed to dump data.`));
-            }
-
-            cli.action.stop(result);
-
-            this.utils.log(message.join('\n'));
+            this.utils.log(res);
+            cli.action.stop();
         });
     }
 }

--- a/packages/cli/src/modules/dbms/dbms.e2e.ts
+++ b/packages/cli/src/modules/dbms/dbms.e2e.ts
@@ -57,7 +57,7 @@ describe('$relate dbms', () => {
 
     skipTestOnWindows.stdout().it('should log failed dump', async (ctx) => {
         await DumpCommand.run([TEST_DB_ID, '--environment', TEST_ENVIRONMENT_ID]);
-        expect(ctx.stdout).toContain('Failed to dump data.');
+        expect(ctx.stdout).toContain('Database does not exist: neo4j');
     });
 
     test.stdout().it('logs start message', async (ctx) => {
@@ -157,7 +157,9 @@ describe('$relate dbms', () => {
             `--to=${path.join(envPaths().data, 'test-db.dump')}`,
             `--environment=${TEST_ENVIRONMENT_ID}`,
         ]);
-        expect(ctx.stdout).toContain('Successfully dumped');
+        expect(ctx.stdout).toContain('data: 100.0%');
+        expect(ctx.stdout).toContain('Done:');
+        expect(ctx.stdout).toContain('processed.');
     });
 
     skipTestOnWindows.stdout().it('should log successful load', async (ctx) => {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,7 +24,9 @@
         "start": "run-s build:clean watch",
         "generate:docs": "typedoc",
         "add:docs": "git add documentation",
-        "version": "run-s generate:docs add:docs"
+        "fix:locks": "npm install --ignore-scripts --no-audit",
+        "add:locks": "git add package-lock.json",
+        "version": "run-s generate:docs add:docs fix:locks add:locks"
     },
     "devDependencies": {
         "@nestjs/common": "7.6.5",

--- a/packages/common/src/utils/dbmss/spawn-promise.ts
+++ b/packages/common/src/utils/dbmss/spawn-promise.ts
@@ -10,13 +10,15 @@ export const spawnPromise = (
 ): Promise<string> => {
     return new Promise((resolve, reject) => {
         let commandEscaped = command;
+        let argsEscaped = args;
         if (process.platform === 'win32') {
             // https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows
             commandEscaped = `"${command}"`;
+            argsEscaped = args.map((arg) => `"${arg}"`);
             options.shell = true;
         }
 
-        const child = spawn(commandEscaped, args, options);
+        const child = spawn(commandEscaped, argsEscaped, options);
 
         if (stream) {
             stream.pipe(child.stdin);

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -22,7 +22,10 @@
         "watch": "tsc -w",
         "test": "jest",
         "start:main": "electron ./dist/dev.js",
-        "start": "run-s build:clean start:main"
+        "start": "run-s build:clean start:main",
+        "fix:locks": "npm install --ignore-scripts --no-audit",
+        "add:locks": "git add package-lock.json",
+        "version": "run-s fix:locks add:locks"
     },
     "devDependencies": {
         "@jest-runner/electron": "3.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,7 +27,10 @@
         "watch:all": "run-p watch",
         "serve:dev": "cross-env NODE_PATH=./node_modules nodemon ./dist/server.js",
         "serve:watch": "run-p watch:all serve:dev",
-        "start": "run-s build:clean serve:watch"
+        "start": "run-s build:clean serve:watch",
+        "fix:locks": "npm install --ignore-scripts --no-audit",
+        "add:locks": "git add package-lock.json",
+        "version": "run-s fix:locks add:locks"
     },
     "devDependencies": {
         "@nestjs/testing": "7.0.8",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix


### What is the current behavior?
- Arguments for the Neo4j scripts are not escaped properly on Windows leading to errors when trying to use paths containing spaces. 
- The `db:dump` command doesn't show the actual error message if the operation fails. 
- Package locks are not updated automatically when releasing.

### What is the new behavior?
- Arguments are now escaped properly, allowing the use of paths with spaces. 
- `db:dump` will show all output from the Neo4j script.
- Package locks should update automatically when releasing.

### Does this PR introduce a breaking change?
No


### Other information: