### PR TITLE
Revert fix for automatically updating package locks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
         "prepare": "run-s lerna:clean lerna:bootstrap",
         "generate:licenses": "node scripts/licenses/index.js",
         "generate:docs": "lerna run generate:docs",
-        "watch": "lerna run watch --stream --parallel"
+        "watch": "lerna run watch --stream --parallel",
+        "fix:locks": "lerna exec \"npm install --ignore-scripts --no-audit\"",
+        "add:locks": "git add packages/*/package-lock.json",
+        "version": "run-s lerna:clean fix:locks add:locks"
     },
     "devDependencies": {
         "@types/node-fetch": "2.5.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -123,9 +123,7 @@
         "test": "jest",
         "generate:docs": "npm run dev-cli -- readme --multi --dir=./docs",
         "add:docs": "git add README.md docs",
-        "fix:locks": "npm install --ignore-scripts --no-audit",
-        "add:locks": "git add package-lock.json",
-        "version": "run-s generate:docs add:docs fix:locks add:locks",
+        "version": "run-s generate:docs add:docs",
         "watch": "tsc -w"
     }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@relate/common",
-    "version": "1.0.3-alpha.4",
+    "version": "1.0.3-alpha.5",
     "description": "JS toolkit",
     "author": "Neo4j Inc.",
     "license": "GPL-3.0",
@@ -24,9 +24,7 @@
         "start": "run-s build:clean watch",
         "generate:docs": "typedoc",
         "add:docs": "git add documentation",
-        "fix:locks": "npm install --ignore-scripts --no-audit",
-        "add:locks": "git add package-lock.json",
-        "version": "run-s generate:docs add:docs fix:locks add:locks"
+        "version": "run-s generate:docs add:docs"
     },
     "devDependencies": {
         "@nestjs/common": "7.6.5",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -22,10 +22,7 @@
         "watch": "tsc -w",
         "test": "jest",
         "start:main": "electron ./dist/dev.js",
-        "start": "run-s build:clean start:main",
-        "fix:locks": "npm install --ignore-scripts --no-audit",
-        "add:locks": "git add package-lock.json",
-        "version": "run-s fix:locks add:locks"
+        "start": "run-s build:clean start:main"
     },
     "devDependencies": {
         "@jest-runner/electron": "3.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,10 +27,7 @@
         "watch:all": "run-p watch",
         "serve:dev": "cross-env NODE_PATH=./node_modules nodemon ./dist/server.js",
         "serve:watch": "run-p watch:all serve:dev",
-        "start": "run-s build:clean serve:watch",
-        "fix:locks": "npm install --ignore-scripts --no-audit",
-        "add:locks": "git add package-lock.json",
-        "version": "run-s fix:locks add:locks"
+        "start": "run-s build:clean serve:watch"
     },
     "devDependencies": {
         "@nestjs/testing": "7.0.8",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Revert commit https://github.com/neo4j-devtools/relate/pull/312/commits/1fd26d52034ddb4814020cba9d66b3cdad9de470 that addresses package locks not updating automatically on releases. The fix didn't actually work and I'll have to spend some more time to find out a better solution.


### What is the current behavior?
(You can also link to an open issue here)


### What is the new behavior?
(if this is a feature change)


### Does this PR introduce a breaking change?
No


### Other information:
