### PR TITLE
Replace hasha with crypto for sha256 check

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@relate/common",
-            "version": "1.0.3-alpha.3",
+            "version": "1.0.3-alpha.6",
             "license": "GPL-3.0",
             "dependencies": {
                 "@neo4j/code-signer": "1.1.3",
@@ -19,7 +19,6 @@
                 "googleapis": "50.0.0",
                 "got": "10.6.0",
                 "graphql-tag": "2.10.3",
-                "hasha": "5.2.0",
                 "jsonwebtoken": "8.5.1",
                 "jszip": "3.5.0",
                 "neo4j-driver-lite": "4.3.0",
@@ -36,7 +35,7 @@
                 "@nestjs/config": "0.4.0",
                 "@nestjs/core": "7.0.8",
                 "@nestjs/testing": "7.0.8",
-                "@relate/types": "^1.0.3-alpha.1",
+                "@relate/types": "^1.0.3-alpha.2",
                 "@types/decompress": "4.2.3",
                 "@types/fs-extra": "9.0.10",
                 "@types/got": "9.6.10",
@@ -1794,9 +1793,9 @@
             }
         },
         "node_modules/@relate/types": {
-            "version": "1.0.3-alpha.1",
-            "resolved": "https://registry.npmjs.org/@relate/types/-/types-1.0.3-alpha.1.tgz",
-            "integrity": "sha512-0LAHjRskY5Rm+We/vmmGRgJ7NCZdiJivIZmzePJnv2tGV+yOGcF+GMdrPVg88nIvVCv1MdxdO8uWKT82CKoBeA==",
+            "version": "1.0.3-alpha.2",
+            "resolved": "https://registry.npmjs.org/@relate/types/-/types-1.0.3-alpha.2.tgz",
+            "integrity": "sha512-aGggfCizmn5qm6lESifTZ8HSVGv9+8II8jPclijOCGloK1rKxXsxSlLklZk+zZKCmMoVMsO105DW1oUmyNo8gA==",
             "dev": true,
             "dependencies": {
                 "lodash": "4.17.21"
@@ -4762,34 +4761,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/hasha": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
-            "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
-            "dependencies": {
-                "is-stream": "^2.0.0",
-                "type-fest": "^0.8.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/hasha/node_modules/is-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/hasha/node_modules/type-fest": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/highlight.js": {
@@ -13401,9 +13372,9 @@
             }
         },
         "@relate/types": {
-            "version": "1.0.3-alpha.1",
-            "resolved": "https://registry.npmjs.org/@relate/types/-/types-1.0.3-alpha.1.tgz",
-            "integrity": "sha512-0LAHjRskY5Rm+We/vmmGRgJ7NCZdiJivIZmzePJnv2tGV+yOGcF+GMdrPVg88nIvVCv1MdxdO8uWKT82CKoBeA==",
+            "version": "1.0.3-alpha.2",
+            "resolved": "https://registry.npmjs.org/@relate/types/-/types-1.0.3-alpha.2.tgz",
+            "integrity": "sha512-aGggfCizmn5qm6lESifTZ8HSVGv9+8II8jPclijOCGloK1rKxXsxSlLklZk+zZKCmMoVMsO105DW1oUmyNo8gA==",
             "dev": true,
             "requires": {
                 "lodash": "4.17.21"
@@ -15877,27 +15848,6 @@
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
-                }
-            }
-        },
-        "hasha": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
-            "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
-            "requires": {
-                "is-stream": "^2.0.0",
-                "type-fest": "^0.8.0"
-            },
-            "dependencies": {
-                "is-stream": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-                },
-                "type-fest": {
-                    "version": "0.8.1",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-                    "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
                 }
             }
         },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -76,7 +76,6 @@
         "googleapis": "50.0.0",
         "got": "10.6.0",
         "graphql-tag": "2.10.3",
-        "hasha": "5.2.0",
         "jsonwebtoken": "8.5.1",
         "jszip": "3.5.0",
         "neo4j-driver-lite": "4.3.0",

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.local.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.local.ts
@@ -213,7 +213,7 @@ export class LocalDbmsPlugins extends DbmsPluginsAbstract<LocalEnvironment> {
                     await emitHookEvent(HOOK_EVENTS.DOWNLOAD_START, null);
                     const downloadedFilePath = await download(pluginToInstall.downloadUrl, pluginCacheDir);
                     if (pluginToInstall.sha256) {
-                        await verifyHash(pluginToInstall.sha256, downloadedFilePath, 'sha256');
+                        await verifyHash(pluginToInstall.sha256, downloadedFilePath);
                     }
                     await fse.move(downloadedFilePath, pluginCacheFilePath, {overwrite: true});
                     await emitHookEvent(HOOK_EVENTS.DOWNLOAD_STOP, null);

--- a/packages/common/src/utils/dbmss/download-neo4j.test.ts
+++ b/packages/common/src/utils/dbmss/download-neo4j.test.ts
@@ -1,7 +1,6 @@
 import fse from 'fs-extra';
 import path from 'path';
 import nock from 'nock';
-import hasha from 'hasha';
 import * as uuid from 'uuid';
 import {List} from '@relate/types';
 import {inc} from 'semver';
@@ -49,9 +48,7 @@ describe('Download Neo4j (to local cache)', () => {
             return Promise.resolve(TMP_PATH);
         });
 
-        const verifyHashSpy = jest
-            .spyOn(downloadNeo4j, 'verifyHash')
-            .mockImplementation(() => Promise.resolve(EXPECTED_HASH_VALUE));
+        const verifyHashSpy = jest.spyOn(download, 'verifyHash').mockImplementation(() => Promise.resolve());
 
         const extractFromArchiveSpy = jest.spyOn(extractNeo4j, 'extractNeo4j').mockImplementation(() =>
             Promise.resolve({
@@ -137,13 +134,13 @@ describe('Download Neo4j (to local cache)', () => {
         afterAll(() => fse.remove(TMP_PATH));
 
         test('hash match', async () => {
-            const hash = await hasha.fromFile(TMP_PATH, {algorithm: NEO4J_SHA_ALGORITHM});
+            const hash = await download.sha256(TMP_PATH);
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            expect(await downloadNeo4j.verifyHash(hash!, TMP_PATH)).toBe(hash);
+            expect(await download.verifyHash(hash!, TMP_PATH)).toBe(undefined);
         });
 
         test('hash mismatch', async () => {
-            await expect(downloadNeo4j.verifyHash(EXPECTED_HASH_VALUE, TMP_PATH)).rejects.toThrow(
+            await expect(download.verifyHash(EXPECTED_HASH_VALUE, TMP_PATH)).rejects.toThrow(
                 new IntegrityError('Expected hash mismatch'),
             );
         });

--- a/packages/common/src/utils/dbmss/download-neo4j.ts
+++ b/packages/common/src/utils/dbmss/download-neo4j.ts
@@ -1,11 +1,10 @@
 import fse from 'fs-extra';
-import hasha from 'hasha';
 import {Str} from '@relate/types';
 
 import {NEO4J_EDITION, NEO4J_SHA_ALGORITHM} from '../../entities/environments/environment.constants';
 import {HOOK_EVENTS} from '../../constants';
-import {FetchError, IntegrityError, NotFoundError} from '../../errors';
-import {download, request} from '../download';
+import {FetchError, NotFoundError} from '../../errors';
+import {download, request, verifyHash} from '../download';
 import {emitHookEvent} from '../event-hooks';
 import {fetchNeo4jVersions} from './dbms-versions';
 import {extractNeo4j} from './extract-neo4j';
@@ -20,20 +19,6 @@ export const getCheckSum = async (url: string): Promise<string> => {
     } catch (e) {
         throw new FetchError(e);
     }
-};
-
-export const verifyHash = async (
-    expectedShasumHash: string,
-    pathToFile: string,
-    algorithm = NEO4J_SHA_ALGORITHM,
-): Promise<string> => {
-    const hash = await hasha.fromFile(pathToFile, {algorithm});
-    if (hash !== expectedShasumHash) {
-        // remove tmp output in this case as it is neither user provided nor trusted
-        await fse.remove(pathToFile);
-        throw new IntegrityError('Expected hash mismatch');
-    }
-    return hash;
 };
 
 export const downloadNeo4j = async (

--- a/packages/common/src/utils/extensions/download-extension.ts
+++ b/packages/common/src/utils/extensions/download-extension.ts
@@ -1,12 +1,11 @@
 import fse from 'fs-extra';
 import path from 'path';
-import hasha from 'hasha';
 
-import {FetchError, NotFoundError, IntegrityError} from '../../errors';
+import {FetchError, NotFoundError} from '../../errors';
 import {extractExtension} from './extract-extension';
-import {EXTENSION_URL_PATH, EXTENSION_SHA_ALGORITHM, HOOK_EVENTS} from '../../constants';
+import {EXTENSION_URL_PATH, HOOK_EVENTS} from '../../constants';
 import {discoverExtension} from './extension-versions';
-import {download, requestJson} from '../download';
+import {download, requestJson, verifyHash} from '../download';
 import {emitHookEvent} from '../event-hooks';
 import {IExtensionInfo} from '../../models';
 
@@ -53,20 +52,6 @@ const fetchExtensionInfo = async (extensionName: string, version: string): Promi
         shasum,
         tarball,
     };
-};
-
-const verifyHash = async (
-    expectedShasumHash: string,
-    pathToFile: string,
-    algorithm = EXTENSION_SHA_ALGORITHM,
-): Promise<string> => {
-    const hash = await hasha.fromFile(pathToFile, {algorithm});
-    if (hash !== expectedShasumHash) {
-        // remove in this case since the file is neither user provided nor trusted
-        await fse.remove(pathToFile);
-        throw new IntegrityError('Expected hash mismatch');
-    }
-    return hash;
 };
 
 export const downloadExtension = async (

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,5 +1,5 @@
 export {registerSystemAccessToken, getSystemAccessToken} from './system-access-token';
 export {envPaths} from './env-paths';
-export {download} from './download';
+export {download, sha256, verifyHash} from './download';
 export {extract} from './extract';
 export * from './event-hooks';


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix


### What is the current behavior?
Recent versions of hasta don't play well with Electron, so when verifying a shasum (after downloading a plugin/DBMS/extension) on a packaged Electron app the method generating the hash hangs indefinitely.


### What is the new behavior?
To generate the hash of downloaded files we now use the core crypto module instead of hasha. 


### Does this PR introduce a breaking change?
No


### Other information:
