### PR TITLE
Allow a DB name to include hyphens

### DIFF
--- a/packages/common/src/entities/dbs/dbs.constants.ts
+++ b/packages/common/src/entities/dbs/dbs.constants.ts
@@ -1,1 +1,1 @@
-export const NEO4J_DB_NAME_REGEX = /^\w+$/;
+export const NEO4J_DB_NAME_REGEX = /^[\w-]+$/;

--- a/packages/common/src/entities/dbs/dbs.local.ts
+++ b/packages/common/src/entities/dbs/dbs.local.ts
@@ -25,7 +25,7 @@ export class LocalDbs extends DbsAbstract<LocalEnvironment> {
                 dbmsNameOrId,
                 dbmsUser,
             },
-            `CREATE DATABASE ${dbName}`,
+            `CREATE DATABASE ${`\`${dbName}\``}`,
         );
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
DB names can have hyphens but currently relate prevents that. This fixes that.

### What is the current behavior?
DB names are checked for invalid chars, which currently includes hyphens.

### What is the new behavior?
Allows hyphens and wraps the DB name with backtiks when creating. 

### Does this PR introduce a breaking change?


### Other information:
