### PR TITLE
Always copy DBMS starter PowerShell script when starting DBMSs

### DIFF
--- a/packages/common/src/utils/dbmss/neo4j-process-win.ts
+++ b/packages/common/src/utils/dbmss/neo4j-process-win.ts
@@ -61,10 +61,8 @@ export const winNeo4jStart = async (dbmsRoot: string): Promise<string> => {
     // relate package are not executable. To avoid issues the starter script is
     // copied in the cache directory and it's executed from there.
     const cachedNeo4jStarterPath = path.join(envPaths().cache, 'neo4j-start.ps1');
-    if (!(await fse.pathExists(cachedNeo4jStarterPath))) {
-        const relateNeo4jStarterPath = path.resolve(__dirname, '..', '..', '..', 'neo4j-start.ps1');
-        await fse.copyFile(relateNeo4jStarterPath, cachedNeo4jStarterPath);
-    }
+    const relateNeo4jStarterPath = path.resolve(__dirname, '..', '..', '..', 'neo4j-start.ps1');
+    await fse.copyFile(relateNeo4jStarterPath, cachedNeo4jStarterPath);
 
     const child = spawn(
         'powershell.exe',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix


### What is the current behavior?
The DBMS starter script is copied only when it doesn't already exist, this means that any changes we make to it will not be applied on upgrades of Relate, unless the script in the cache is manually deleted. 


### What is the new behavior?
The DBMS starter script is copied every time a DBMS is started on Windows. This way we ensure it's always up to date. 


### Does this PR introduce a breaking change?
No


### Other information:
