### PR TITLE
Changed default behaviour of Monad.map() and Maybe.map()

### DIFF
--- a/packages/common/src/utils/dbmss/download-neo4j.ts
+++ b/packages/common/src/utils/dbmss/download-neo4j.ts
@@ -33,8 +33,13 @@ export const downloadNeo4j = async (
         const mappedVersions = onlineVersions
             .mapEach((dist) => `${dist.version}-${dist.edition}`)
             .join(', ')
-            .map((versions) => `Use a valid version found online: ${versions}`)
-            .getOrElse(`Use a valid version`);
+            .flatMap((versions) => {
+                if (versions) {
+                    return `Use a valid version found online: ${versions}`;
+                }
+
+                return `Use a valid version`;
+            });
 
         throw new NotFoundError(`Unable to find the requested version: ${version}-${edition} online`, [mappedVersions]);
     };

--- a/packages/types/src/monads/monad.ts
+++ b/packages/types/src/monads/monad.ts
@@ -163,9 +163,6 @@ export default class Monad<T> implements IMonad<T> {
      * ```
      */
     map(project: (value: T) => T): this {
-        if (this.isEmpty) {
-            return this;
-        }
         // @ts-ignore
         return new this.constructor(project(this.original));
     }

--- a/packages/types/src/monads/primitive/list.monad.ts
+++ b/packages/types/src/monads/primitive/list.monad.ts
@@ -1,4 +1,4 @@
-import {join, filter, find, map, forEach, without, uniq, uniqBy} from 'lodash';
+import {chunk, join, filter, find, map, forEach, without, uniq, uniqBy, ArrayIterator} from 'lodash';
 
 import Monad from '../monad';
 import Maybe from './maybe.monad';
@@ -150,6 +150,14 @@ export default class List<T> extends Monad<Iterable<T>> {
     }
 
     /**
+     * Creates an List of Nones of a given length
+     * @see {@link List.of}
+     */
+    static ofLength<T>(length: number | Num): List<None<T>> {
+        return Num.from(length).flatMap((n) => List.from(Array(n).fill(None.EMPTY)));
+    }
+
+    /**
      * @hidden
      */
     // @ts-ignore
@@ -224,7 +232,7 @@ export default class List<T> extends Monad<Iterable<T>> {
      * end.toArray() // [2,3,4]
      * ```
      */
-    mapEach<M = T>(project: (val: T) => M): List<M> {
+    mapEach<M = T>(project: ArrayIterator<T, M>): List<M> {
         return List.from(map([...this], project));
     }
 
@@ -237,7 +245,7 @@ export default class List<T> extends Monad<Iterable<T>> {
      * end.toArray() // [1,2,3]
      * ```
      */
-    forEach(project: (val: T) => void): this {
+    forEach(project: ArrayIterator<T, any>): this {
         forEach([...this], project);
 
         return this;
@@ -326,6 +334,12 @@ export default class List<T> extends Monad<Iterable<T>> {
 
         // @ts-ignore
         return this.map(uniq);
+    }
+
+    chunk(size: number | Num = 1): List<List<T>> {
+        const inChunks = chunk(this.toArray(), Num.from(size).getOrElse(1));
+
+        return List.from(inChunks).mapEach(List.from);
     }
 
     toString() {

--- a/packages/types/src/monads/primitive/maybe.monad.ts
+++ b/packages/types/src/monads/primitive/maybe.monad.ts
@@ -57,6 +57,18 @@ export default class Maybe<T> extends Monad<T | None<T>> {
     }
 
     /**
+     * @hidden
+     */
+    map<R = T extends None<infer E> ? E : T>(project: (value: R) => R): this {
+        if (this.isEmpty) {
+            return this;
+        }
+
+        // @ts-ignore
+        return new this.constructor(project(this.original));
+    }
+
+    /**
      * Wraps passed value in Maybe regardless of what it is
      *
      * ```ts


### PR DESCRIPTION
- Also added new List methods `ofLength()` and `chunk()`

### Please check if the PR fulfills these requirements
- [ ] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
This PR changes the default behaviour of `Monad.map()` to always run their callback even if monad is empty. Conversely, this PR changes the default behaviour of `Maybe.map()` to only run their callback if Maybe is NOT empty.

Further this PR adds two new convenience methods to the List monad `ofLength()` and `chunk()`


### What is the current behavior?
Empty monads do not run their `.map()` callback. This is something that is expected only for Maybes IMO


### What is the new behavior?
Empty Maybes do not run their `.map()` callback


### Does this PR introduce a breaking change?
Yes, we had a test case that was relying on this implied behaviour. The case looks more sensible now that it is corrected


### Other information:
AFAIK this was never an expected behaviour but it could be that we are relying on it elsewhere. Are our tests strong enough to catch the scope of this change?