### PR TITLE
Revert overwriting of neo4j-start.ps1 when starting DBMSs

### DIFF
--- a/packages/common/src/utils/dbmss/neo4j-process-win.ts
+++ b/packages/common/src/utils/dbmss/neo4j-process-win.ts
@@ -62,7 +62,10 @@ export const winNeo4jStart = async (dbmsRoot: string): Promise<string> => {
     // copied in the cache directory and it's executed from there.
     const cachedNeo4jStarterPath = path.join(envPaths().cache, 'neo4j-start.ps1');
     const relateNeo4jStarterPath = path.resolve(__dirname, '..', '..', '..', 'neo4j-start.ps1');
-    await fse.copyFile(relateNeo4jStarterPath, cachedNeo4jStarterPath);
+
+    if (!(await fse.pathExists(cachedNeo4jStarterPath))) {
+        await fse.copyFile(relateNeo4jStarterPath, cachedNeo4jStarterPath);
+    }
 
     const child = spawn(
         'powershell.exe',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Revert overwriting the PowerShell script used to start DBMSs.


### What is the current behavior?
(You can also link to an open issue here)


### What is the new behavior?
(if this is a feature change)


### Does this PR introduce a breaking change?
No


### Other information:
This change is temporary until we find a better way to distribute the signed PowerShell script, and until we have a better solution for running this script in environments where background PowerShell processes are not allowed.