### PR TITLE
Revert typedoc upgrade, add table flags to env:list command

### DIFF
--- a/packages/cli/docs/environment.md
+++ b/packages/cli/docs/environment.md
@@ -81,6 +81,15 @@ List all available environments
 USAGE
   $ relate environment:list
 
+OPTIONS
+  -x, --extended          show extra columns
+  --columns=columns       only show provided columns (comma-separated)
+  --filter=filter         filter property by partial string matching, ex: name=foo
+  --no-header             hide table header from output
+  --no-truncate           do not truncate output to fit screen
+  --output=csv|json|yaml  output in a more machine friendly format
+  --sort=sort             property to sort by (prepend '-' for descending)
+
 ALIASES
   $ relate env:list
 

--- a/packages/cli/src/commands/environment/list.ts
+++ b/packages/cli/src/commands/environment/list.ts
@@ -1,3 +1,5 @@
+import cli from 'cli-ux';
+
 import BaseCommand from '../../base.command';
 import {ListModule} from '../../modules/environment/list.module';
 
@@ -11,4 +13,8 @@ export default class ListCommand extends BaseCommand {
     static examples = ['$ relate env:list'];
 
     static aliases = ['env:list'];
+
+    static flags = {
+        ...cli.table.flags({except: ['csv']}),
+    };
 }

--- a/packages/types/package-lock.json
+++ b/packages/types/package-lock.json
@@ -16,9 +16,9 @@
                 "@types/lodash": "4.14.172",
                 "jest": "27.1.0",
                 "ts-jest": "27.0.5",
-                "typedoc": "0.21.9",
-                "typedoc-plugin-markdown": "3.10.4",
-                "typedoc-plugin-no-inherit": "1.3.0",
+                "typedoc": "0.17.7",
+                "typedoc-plugin-markdown": "2.3.1",
+                "typedoc-plugin-no-inherit": "1.1.10",
                 "typescript": "4.4.2"
             }
         },
@@ -1155,6 +1155,15 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
+        "node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
         "node_modules/babel-jest": {
             "version": "27.1.0",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
@@ -1834,6 +1843,20 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1976,6 +1999,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/html-encoding-sniffer": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -2082,6 +2114,15 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
+        },
+        "node_modules/interpret": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
         },
         "node_modules/is-ci": {
             "version": "3.0.0",
@@ -2964,6 +3005,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "node_modules/kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -3061,15 +3111,15 @@
             }
         },
         "node_modules/marked": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.2.tgz",
-            "integrity": "sha512-TMJQQ79Z0e3rJYazY0tIoMsFzteUGw9fB3FD+gzuIT3zLuG9L9ckIvUfF51apdJkcqc208jJN2KbtPbOvXtbjA==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+            "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
             "dev": true,
             "bin": {
                 "marked": "bin/marked"
             },
             "engines": {
-                "node": ">= 12"
+                "node": ">= 8.16.2"
             }
         },
         "node_modules/merge-stream": {
@@ -3228,30 +3278,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/onigasm": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-            "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^5.1.1"
-            }
-        },
-        "node_modules/onigasm/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
-        "node_modules/onigasm/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true
         },
         "node_modules/optionator": {
             "version": "0.8.3",
@@ -3472,6 +3498,18 @@
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
         },
+        "node_modules/rechoir": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
+            "dependencies": {
+                "resolve": "^1.1.6"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3584,15 +3622,21 @@
                 "node": ">=8"
             }
         },
-        "node_modules/shiki": {
-            "version": "0.9.8",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.8.tgz",
-            "integrity": "sha512-499zQUTjcNTVwwiaPrWldUTXIV3T9HZWxDwE82bY+9GE7P2uD6hpHUTXNbTof3iOG6WT+/062+OMbl0lDoG8WQ==",
+        "node_modules/shelljs": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+            "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
             "dev": true,
             "dependencies": {
-                "json5": "^2.2.0",
-                "onigasm": "^2.2.5",
-                "vscode-textmate": "5.2.0"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
+            },
+            "bin": {
+                "shjs": "bin/shjs"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/signal-exit": {
@@ -3925,58 +3969,103 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.21.9",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.9.tgz",
-            "integrity": "sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==",
+            "version": "0.17.7",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.7.tgz",
+            "integrity": "sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==",
             "dev": true,
             "dependencies": {
-                "glob": "^7.1.7",
-                "handlebars": "^4.7.7",
-                "lunr": "^2.3.9",
-                "marked": "^3.0.2",
+                "fs-extra": "^8.1.0",
+                "handlebars": "^4.7.6",
+                "highlight.js": "^10.0.0",
+                "lodash": "^4.17.15",
+                "lunr": "^2.3.8",
+                "marked": "1.0.0",
                 "minimatch": "^3.0.0",
                 "progress": "^2.0.3",
-                "shiki": "^0.9.8",
-                "typedoc-default-themes": "^0.12.10"
+                "shelljs": "^0.8.4",
+                "typedoc-default-themes": "^0.10.1"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
             },
             "engines": {
-                "node": ">= 12.10.0"
+                "node": ">= 8.0.0"
             },
             "peerDependencies": {
-                "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+                "typescript": ">=3.8.3"
             }
         },
         "node_modules/typedoc-default-themes": {
-            "version": "0.12.10",
-            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
-            "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+            "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
             "dev": true,
+            "dependencies": {
+                "lunr": "^2.3.8"
+            },
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/typedoc-plugin-markdown": {
-            "version": "3.10.4",
-            "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.10.4.tgz",
-            "integrity": "sha512-if9w7S9fXLg73AYi/EoRSEhTOZlg3I8mIP8YEmvzSE33VrNXC9/hA0nVcLEwFVJeQY7ay6z67I6kW0KIv7LjeA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.3.1.tgz",
+            "integrity": "sha512-7rlmg1tLjddYy11uznHCAlyoOpxdWnFXqGEZ7j2mJ4KJg2avwWgEpw6SFZVofgPCGn36zklpFS51lHxYSRTLVQ==",
             "dev": true,
             "dependencies": {
-                "handlebars": "^4.7.7"
+                "fs-extra": "^9.0.0",
+                "handlebars": "^4.7.6"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
             },
             "peerDependencies": {
-                "typedoc": ">=0.21.2"
+                "typedoc": ">=0.17.0"
+            }
+        },
+        "node_modules/typedoc-plugin-markdown/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/typedoc-plugin-markdown/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/typedoc-plugin-markdown/node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/typedoc-plugin-no-inherit": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.3.0.tgz",
-            "integrity": "sha512-Om4yu8sDHkHWi6FcOYUbg6fv2jh7kS51xbuZ/zs4VEtO5bJwTkO8FlzRUyDrTA3puxvF9XcoottntD0mpEgULg==",
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.1.10.tgz",
+            "integrity": "sha512-BhSFAWlBTh9Bf6PSfruIqdQBM8gd/Gj8hVuRk5pVWkHu4I/SB24LzFr5gAo52ZlaQSeN72+VOkkRD6tNYl8Enw==",
             "dev": true,
             "peerDependencies": {
-                "typedoc": ">=0.20.31"
+                "typedoc": ">=0.10.0"
             }
         },
         "node_modules/typescript": {
@@ -4036,12 +4125,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/vscode-textmate": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
-            "dev": true
         },
         "node_modules/w3c-hr-time": {
             "version": "1.0.2",
@@ -5157,6 +5240,12 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
+        "at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true
+        },
         "babel-jest": {
             "version": "27.1.0",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
@@ -5680,6 +5769,17 @@
                 "mime-types": "^2.1.12"
             }
         },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5777,6 +5877,12 @@
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true
         },
+        "highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "dev": true
+        },
         "html-encoding-sniffer": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -5858,6 +5964,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "interpret": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
         },
         "is-ci": {
@@ -6543,6 +6655,15 @@
                 "minimist": "^1.2.5"
             }
         },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6619,9 +6740,9 @@
             }
         },
         "marked": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.2.tgz",
-            "integrity": "sha512-TMJQQ79Z0e3rJYazY0tIoMsFzteUGw9fB3FD+gzuIT3zLuG9L9ckIvUfF51apdJkcqc208jJN2KbtPbOvXtbjA==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+            "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
             "dev": true
         },
         "merge-stream": {
@@ -6749,32 +6870,6 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
-            }
-        },
-        "onigasm": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-            "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^5.1.1"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^3.0.2"
-                    }
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-                    "dev": true
-                }
             }
         },
         "optionator": {
@@ -6935,6 +7030,15 @@
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
         },
+        "rechoir": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
+            "requires": {
+                "resolve": "^1.1.6"
+            }
+        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7017,15 +7121,15 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
-        "shiki": {
-            "version": "0.9.8",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.8.tgz",
-            "integrity": "sha512-499zQUTjcNTVwwiaPrWldUTXIV3T9HZWxDwE82bY+9GE7P2uD6hpHUTXNbTof3iOG6WT+/062+OMbl0lDoG8WQ==",
+        "shelljs": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+            "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
             "dev": true,
             "requires": {
-                "json5": "^2.2.0",
-                "onigasm": "^2.2.5",
-                "vscode-textmate": "5.2.0"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
             }
         },
         "signal-exit": {
@@ -7267,40 +7371,76 @@
             }
         },
         "typedoc": {
-            "version": "0.21.9",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.9.tgz",
-            "integrity": "sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==",
+            "version": "0.17.7",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.7.tgz",
+            "integrity": "sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.7",
-                "handlebars": "^4.7.7",
-                "lunr": "^2.3.9",
-                "marked": "^3.0.2",
+                "fs-extra": "^8.1.0",
+                "handlebars": "^4.7.6",
+                "highlight.js": "^10.0.0",
+                "lodash": "^4.17.15",
+                "lunr": "^2.3.8",
+                "marked": "1.0.0",
                 "minimatch": "^3.0.0",
                 "progress": "^2.0.3",
-                "shiki": "^0.9.8",
-                "typedoc-default-themes": "^0.12.10"
+                "shelljs": "^0.8.4",
+                "typedoc-default-themes": "^0.10.1"
             }
         },
         "typedoc-default-themes": {
-            "version": "0.12.10",
-            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
-            "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
-            "dev": true
-        },
-        "typedoc-plugin-markdown": {
-            "version": "3.10.4",
-            "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.10.4.tgz",
-            "integrity": "sha512-if9w7S9fXLg73AYi/EoRSEhTOZlg3I8mIP8YEmvzSE33VrNXC9/hA0nVcLEwFVJeQY7ay6z67I6kW0KIv7LjeA==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+            "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.7.7"
+                "lunr": "^2.3.8"
+            }
+        },
+        "typedoc-plugin-markdown": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.3.1.tgz",
+            "integrity": "sha512-7rlmg1tLjddYy11uznHCAlyoOpxdWnFXqGEZ7j2mJ4KJg2avwWgEpw6SFZVofgPCGn36zklpFS51lHxYSRTLVQ==",
+            "dev": true,
+            "requires": {
+                "fs-extra": "^9.0.0",
+                "handlebars": "^4.7.6"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
             }
         },
         "typedoc-plugin-no-inherit": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.3.0.tgz",
-            "integrity": "sha512-Om4yu8sDHkHWi6FcOYUbg6fv2jh7kS51xbuZ/zs4VEtO5bJwTkO8FlzRUyDrTA3puxvF9XcoottntD0mpEgULg==",
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.1.10.tgz",
+            "integrity": "sha512-BhSFAWlBTh9Bf6PSfruIqdQBM8gd/Gj8hVuRk5pVWkHu4I/SB24LzFr5gAo52ZlaQSeN72+VOkkRD6tNYl8Enw==",
             "dev": true,
             "requires": {}
         },
@@ -7341,12 +7481,6 @@
                     "dev": true
                 }
             }
-        },
-        "vscode-textmate": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
-            "dev": true
         },
         "w3c-hr-time": {
             "version": "1.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -33,9 +33,9 @@
         "@types/lodash": "4.14.172",
         "jest": "27.1.0",
         "ts-jest": "27.0.5",
-        "typedoc": "0.21.9",
-        "typedoc-plugin-markdown": "3.10.4",
-        "typedoc-plugin-no-inherit": "1.3.0",
+        "typedoc": "0.17.7",
+        "typedoc-plugin-markdown": "2.3.1",
+        "typedoc-plugin-no-inherit": "1.1.10",
         "typescript": "4.4.2"
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Fix docs generation and add new flags to `env:list`.


### What is the current behavior?
- Generating new docs for the types package is failing because of breaking changes in the upgraded typedoc version.
- The `env:list` CLI command doesn't accept any flags.


### What is the new behavior?
- Reverted to the previously working version of typedoc. 
- The `env:list` CLI command now accepts the same table flags as the other list commands (eg. filter, output, sort).


### Does this PR introduce a breaking change?
No

### Other information:
