### PR TITLE
dbms-plugins resolvers and tests added

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -162,6 +162,14 @@ export enum PUBLIC_GRAPHQL_METHODS {
     DROP_DB = 'dropDb',
     LIST_DBS = 'listDbs',
 
+    // dbms-plugins
+    LIST_DBMS_PLUGINS = 'listDbmsPlugins',
+    INSTALL_DBMS_PLUGIN = 'installDbmsPlugin',
+    UNINSTALL_DBMS_PLUGIN = 'uninstallDbmsPlugin',
+    LIST_DBMS_PLUGIN_SOURCES = 'listDbmsPluginSources',
+    ADD_DBMS_PLUGIN_SOURCES = 'addDbmsPluginSources',
+    REMOVE_DBMS_PLUGIN_SOURCES = 'removeDbmsPluginSources',
+
     // apps
     LIST_APPS = 'listApps',
     APP_LAUNCH_DATA = 'appLaunchData',

--- a/packages/web/src/entities/dbms-plugins/dbms-plugins.e2e.ts
+++ b/packages/web/src/entities/dbms-plugins/dbms-plugins.e2e.ts
@@ -1,0 +1,268 @@
+/* eslint-disable max-len */
+import {INestApplication} from '@nestjs/common';
+import {Test} from '@nestjs/testing';
+import {IDbmsPluginSource, NEO4J_PLUGIN_SOURCES_URL, TestDbmss} from '@relate/common';
+import {ConfigModule} from '@nestjs/config';
+import request from 'supertest';
+import nock from 'nock';
+
+import configuration from '../../configs/dev.config';
+import {WebModule} from '../../web.module';
+
+let TEST_DBMS_NAME: string;
+let TEST_DBMS_ID: string;
+
+const HTTP_OK = 200;
+
+const queryBody = (query: string, variables?: {[key: string]: any}): {[key: string]: any} => ({
+    query,
+    variables: {
+        dbmsName: TEST_DBMS_NAME,
+        dbmsNames: [TEST_DBMS_NAME],
+        dbmsId: TEST_DBMS_ID,
+        dbmsIds: [TEST_DBMS_ID],
+        environmentNameOrId: 'test',
+        ...variables,
+    },
+});
+
+const PLUGIN_SOURCES_ORIGIN = new URL(NEO4J_PLUGIN_SOURCES_URL).origin;
+const PLUGIN_SOURCES_PATHNAME = new URL(NEO4J_PLUGIN_SOURCES_URL).pathname;
+
+const APOC_SOURCE: IDbmsPluginSource = {
+    name: 'apoc',
+    homepageUrl: 'https://github.com/neo4j-contrib/neo4j-apoc-procedures',
+    versionsUrl: 'https://neo4j-contrib.github.io/neo4j-apoc-procedures/versions.json',
+};
+
+const TEST_SOURCE: IDbmsPluginSource = {
+    name: 'test-plugin-1',
+    homepageUrl: 'https://github.com/neo4j-contrib/test-plugin-1',
+    versionsUrl: 'https://neo4j-contrib.github.io/test-plugin-1/versions.json',
+};
+
+describe('DBMSPluginsModule', () => {
+    let app: INestApplication;
+    let dbmss: TestDbmss;
+
+    beforeAll(async () => {
+        dbmss = await TestDbmss.init(__filename);
+        const {name, id} = await dbmss.createDbms();
+
+        TEST_DBMS_NAME = name;
+        TEST_DBMS_ID = id;
+
+        const module = await Test.createTestingModule({
+            imports: [
+                ConfigModule.forRoot({
+                    isGlobal: true,
+                    load: [configuration],
+                }),
+                WebModule.register({
+                    defaultEnvironmentNameOrId: dbmss.environment.id,
+                    ...configuration(),
+                }),
+            ],
+        }).compile();
+
+        app = module.createNestApplication();
+        await app.init();
+    });
+
+    afterAll(() => {
+        dbmss.teardown();
+        nock.cleanAll();
+    });
+
+    describe('dbms stopped', () => {
+        test('/graphql listDbmsPlugins (initial)', () => {
+            return request(app.getHttpServer())
+                .post('/graphql')
+                .send(
+                    queryBody(
+                        `query ListDBMSPlugins($environmentNameOrId: String, $dbmsId: String!) {
+                              listDbmsPlugins(environmentNameOrId: $environmentNameOrId, dbmsId: $dbmsId) {
+                                name
+                                homepageUrl
+                                versionsUrl
+                                version {
+                                  version
+                                }
+                              }
+                          }`,
+                    ),
+                )
+                .expect(HTTP_OK)
+                .expect((res: request.Response) => {
+                    const {listDbmsPlugins} = res.body.data;
+                    expect(listDbmsPlugins).toHaveLength(1);
+                    expect(listDbmsPlugins).toEqual([
+                        {
+                            name: 'neo4j-jwt-addon',
+                            homepageUrl: 'https://github.com/neo4j-devtools/relate',
+                            version: {
+                                version: '1.0.2',
+                            },
+                            versionsUrl:
+                                'https://s3-eu-west-1.amazonaws.com/dist.neo4j.org/relate/neo4j-jwt-addon/versions.json',
+                        },
+                    ]);
+                });
+        });
+    });
+
+    test('/graphql installDbmsPlugin (plugin that exists)', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `mutation InstallDBMSPlugin($environmentNameOrId: String, $dbmsIds: [String!]!, $pluginName: String!) {
+                            installDbmsPlugin(environmentNameOrId: $environmentNameOrId, dbmsIds: $dbmsIds, pluginName: $pluginName) {
+                                name
+                          }
+                      }`,
+                    {
+                        pluginName: 'apoc',
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect(async (res: request.Response) => {
+                const {installDbmsPlugin} = res.body.data;
+                expect(installDbmsPlugin).toHaveLength(1);
+                expect(installDbmsPlugin).toEqual([
+                    {
+                        name: 'apoc',
+                    },
+                ]);
+                const installedPlugins = await dbmss.environment.dbmsPlugins.list(TEST_DBMS_ID);
+                expect(installedPlugins.mapEach((p) => ({name: p.name})).toArray()).toEqual([
+                    {
+                        name: 'apoc',
+                    },
+                    {
+                        name: 'neo4j-jwt-addon',
+                    },
+                ]);
+            });
+    });
+
+    test('/graphql uninstallDbmsPlugin', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `mutation UninstallDBMSPlugin($environmentNameOrId: String, $dbmsIds: [String!]!, $pluginName: String!) {
+                            uninstallDbmsPlugin(environmentNameOrId: $environmentNameOrId, dbmsIds: $dbmsIds, pluginName: $pluginName) {
+                                dbmsIds
+                                pluginName
+                            }
+                      }`,
+                    {
+                        pluginName: 'apoc',
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect(async (res: request.Response) => {
+                const {uninstallDbmsPlugin} = res.body.data;
+                expect(uninstallDbmsPlugin.dbmsIds).toHaveLength(1);
+                expect(uninstallDbmsPlugin.dbmsIds[0]).toBe(TEST_DBMS_ID);
+                expect(uninstallDbmsPlugin.pluginName).toBe('apoc');
+                const installedPlugins = await dbmss.environment.dbmsPlugins.list(TEST_DBMS_ID);
+                expect(installedPlugins.mapEach((p) => ({name: p.name})).toArray()).toEqual([
+                    {
+                        name: 'neo4j-jwt-addon',
+                    },
+                ]);
+            });
+    });
+
+    test('/graphql listDbmsPluginSources (initial)', () => {
+        nock(PLUGIN_SOURCES_ORIGIN)
+            .get(PLUGIN_SOURCES_PATHNAME)
+            .reply(200, {
+                apoc: {
+                    homepageUrl: 'https://github.com/neo4j-contrib/neo4j-apoc-procedures',
+                    versionsUrl: 'https://neo4j-contrib.github.io/neo4j-apoc-procedures/versions.json',
+                },
+            });
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `query ListDBMSPluginSources($environmentNameOrId: String) {
+                          listDbmsPluginSources(environmentNameOrId: $environmentNameOrId) {
+                            name
+                            homepageUrl
+                            versionsUrl
+                          }
+                      }`,
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {listDbmsPluginSources} = res.body.data;
+                expect(listDbmsPluginSources).toHaveLength(2);
+                expect(listDbmsPluginSources).toEqual([
+                    APOC_SOURCE,
+                    {
+                        name: 'neo4j-jwt-addon',
+                        homepageUrl: 'https://github.com/neo4j-devtools/relate',
+                        versionsUrl:
+                            'https://s3-eu-west-1.amazonaws.com/dist.neo4j.org/relate/neo4j-jwt-addon/versions.json',
+                    },
+                ]);
+            });
+    });
+
+    test('/graphql addDbmsPluginSources', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `mutation AddDBMSPluginSources($environmentNameOrId: String, $sources: [DbmsPluginSourceInput!]!) {
+                        addDbmsPluginSources(environmentNameOrId: $environmentNameOrId, sources: $sources) {
+                            name
+                            homepageUrl
+                            versionsUrl
+                          }
+                      }`,
+                    {
+                        sources: [TEST_SOURCE],
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {addDbmsPluginSources} = res.body.data;
+                expect(addDbmsPluginSources).toHaveLength(1);
+                expect(addDbmsPluginSources).toEqual([TEST_SOURCE]);
+            });
+    });
+
+    test('/graphql removeDbmsPluginSources (unofficial)', () => {
+        return request(app.getHttpServer())
+            .post('/graphql')
+            .send(
+                queryBody(
+                    `mutation RemoveDBMSPluginSources($environmentNameOrId: String, $names: [String!]!) {
+                        removeDbmsPluginSources(environmentNameOrId: $environmentNameOrId, names: $names) {
+                            name
+                            homepageUrl
+                            versionsUrl
+                          }
+                      }`,
+                    {
+                        names: [TEST_SOURCE.name],
+                    },
+                ),
+            )
+            .expect(HTTP_OK)
+            .expect((res: request.Response) => {
+                const {removeDbmsPluginSources} = res.body.data;
+                expect(removeDbmsPluginSources).toHaveLength(1);
+                expect(removeDbmsPluginSources).toEqual([TEST_SOURCE]);
+            });
+    });
+});

--- a/packages/web/src/entities/dbms-plugins/dbms-plugins.module.ts
+++ b/packages/web/src/entities/dbms-plugins/dbms-plugins.module.ts
@@ -1,0 +1,11 @@
+import {Module} from '@nestjs/common';
+
+import {SystemModule} from '@relate/common';
+import {DBMSPluginsResolver} from './dbms-plugins.resolver';
+
+@Module({
+    exports: [],
+    imports: [SystemModule],
+    providers: [DBMSPluginsResolver],
+})
+export class DBMSPluginsModule {}

--- a/packages/web/src/entities/dbms-plugins/dbms-plugins.resolver.ts
+++ b/packages/web/src/entities/dbms-plugins/dbms-plugins.resolver.ts
@@ -1,0 +1,88 @@
+import {Inject, UseGuards, UseInterceptors} from '@nestjs/common';
+import {Args, Context, Mutation, Query, Resolver} from '@nestjs/graphql';
+import {
+    Environment,
+    IDbmsPluginInstalled,
+    IDbmsPluginSource,
+    PUBLIC_GRAPHQL_METHODS,
+    SystemProvider,
+} from '@relate/common';
+import {List} from '@relate/types';
+
+import {EnvironmentArgs, FilterArgs} from '../../global.types';
+import {EnvironmentGuard} from '../../guards/environment.guard';
+import {EnvironmentInterceptor} from '../../interceptors/environment.interceptor';
+import {DbmsArgs, DbmssArgs} from '../dbms/dbms.types';
+import {
+    AddDbmsPluginSources,
+    DbmsPluginInstalled,
+    DbmsPluginSource,
+    PluginNameArgs,
+    RemoveDbmsPluginSources,
+    UninstallDbmsPluginReturn,
+} from './dbms-plugins.types';
+
+@Resolver(() => String)
+@UseGuards(EnvironmentGuard)
+@UseInterceptors(EnvironmentInterceptor)
+export class DBMSPluginsResolver {
+    constructor(@Inject(SystemProvider) protected readonly systemProvider: SystemProvider) {}
+
+    @Query(() => [DbmsPluginInstalled])
+    async [PUBLIC_GRAPHQL_METHODS.LIST_DBMS_PLUGINS](
+        @Context('environment') environment: Environment,
+        @Args() {dbmsId}: DbmsArgs,
+        @Args() {filters}: FilterArgs,
+    ): Promise<List<IDbmsPluginInstalled>> {
+        return environment.dbmsPlugins.list(dbmsId, filters);
+    }
+
+    @Mutation(() => [DbmsPluginInstalled])
+    async [PUBLIC_GRAPHQL_METHODS.INSTALL_DBMS_PLUGIN](
+        @Context('environment') environment: Environment,
+        @Args() {dbmsIds}: DbmssArgs,
+        @Args() {pluginName}: PluginNameArgs,
+    ): Promise<List<IDbmsPluginInstalled>> {
+        return environment.dbmsPlugins.install(dbmsIds, pluginName);
+    }
+
+    @Mutation(() => UninstallDbmsPluginReturn, {nullable: true})
+    async [PUBLIC_GRAPHQL_METHODS.UNINSTALL_DBMS_PLUGIN](
+        @Context('environment') environment: Environment,
+        @Args() {dbmsIds}: DbmssArgs,
+        @Args() {pluginName}: PluginNameArgs,
+    ): Promise<UninstallDbmsPluginReturn> {
+        await environment.dbmsPlugins.uninstall(dbmsIds, pluginName);
+        return {
+            dbmsIds,
+            pluginName,
+        };
+    }
+
+    @Query(() => [DbmsPluginSource])
+    async [PUBLIC_GRAPHQL_METHODS.LIST_DBMS_PLUGIN_SOURCES](
+        @Context('environment') environment: Environment,
+        @Args() _env: EnvironmentArgs,
+        @Args() {filters}: FilterArgs,
+    ): Promise<List<IDbmsPluginSource>> {
+        return environment.dbmsPlugins.listSources(filters);
+    }
+
+    @Mutation(() => [DbmsPluginSource])
+    async [PUBLIC_GRAPHQL_METHODS.ADD_DBMS_PLUGIN_SOURCES](
+        @Context('environment') environment: Environment,
+        @Args() _env: EnvironmentArgs,
+        @Args() {sources}: AddDbmsPluginSources,
+    ): Promise<List<IDbmsPluginSource>> {
+        return environment.dbmsPlugins.addSources(sources);
+    }
+
+    @Mutation(() => [DbmsPluginSource])
+    async [PUBLIC_GRAPHQL_METHODS.REMOVE_DBMS_PLUGIN_SOURCES](
+        @Context('environment') environment: Environment,
+        @Args() _env: EnvironmentArgs,
+        @Args() {names}: RemoveDbmsPluginSources,
+    ): Promise<List<IDbmsPluginSource>> {
+        return environment.dbmsPlugins.removeSources(names);
+    }
+}

--- a/packages/web/src/entities/dbms-plugins/dbms-plugins.types.ts
+++ b/packages/web/src/entities/dbms-plugins/dbms-plugins.types.ts
@@ -1,0 +1,79 @@
+import {ArgsType, Field, InputType, ObjectType} from '@nestjs/graphql';
+import {DbmsPluginConfig, IDbmsPluginInstalled, IDbmsPluginSource, IDbmsPluginVersion} from '@relate/common';
+import {GraphQLJSONObject} from 'graphql-type-json';
+
+@ObjectType()
+export class DbmsPluginVersion implements IDbmsPluginVersion {
+    @Field(() => String)
+    version: string;
+
+    @Field(() => String)
+    neo4jVersion: string;
+
+    @Field(() => String, {nullable: true})
+    homepageUrl?: string;
+
+    @Field(() => String)
+    downloadUrl: string;
+
+    @Field(() => String, {nullable: true})
+    sha256?: string;
+
+    @Field(() => GraphQLJSONObject)
+    config: DbmsPluginConfig;
+}
+
+@ObjectType({isAbstract: true})
+@InputType({isAbstract: true})
+export class DbmsPluginSourceBase implements IDbmsPluginSource {
+    @Field(() => String)
+    name: string;
+
+    @Field(() => String)
+    homepageUrl: string;
+
+    @Field(() => String)
+    versionsUrl: string;
+
+    @Field(() => Boolean, {nullable: true})
+    isOfficial?: boolean;
+}
+
+@ObjectType()
+export class DbmsPluginSource extends DbmsPluginSourceBase {}
+
+@ObjectType()
+export class DbmsPluginInstalled extends DbmsPluginSourceBase implements IDbmsPluginInstalled {
+    @Field(() => DbmsPluginVersion)
+    version: DbmsPluginVersion;
+}
+
+@ArgsType()
+export class PluginNameArgs {
+    @Field(() => String)
+    pluginName: string;
+}
+
+@ObjectType()
+export class UninstallDbmsPluginReturn {
+    @Field(() => [String])
+    dbmsIds: string[];
+
+    @Field(() => String)
+    pluginName: string;
+}
+
+@InputType()
+export class DbmsPluginSourceInput extends DbmsPluginSourceBase {}
+
+@ArgsType()
+export class AddDbmsPluginSources {
+    @Field(() => [DbmsPluginSourceInput])
+    sources: DbmsPluginSourceInput[];
+}
+
+@ArgsType()
+export class RemoveDbmsPluginSources {
+    @Field(() => [String])
+    names: string[];
+}

--- a/packages/web/src/entities/dbms-plugins/index.ts
+++ b/packages/web/src/entities/dbms-plugins/index.ts
@@ -1,0 +1,1 @@
+export {DBMSPluginsModule} from './dbms-plugins.module';

--- a/packages/web/src/web.module.ts
+++ b/packages/web/src/web.module.ts
@@ -16,6 +16,7 @@ import {AuthModule} from './auth';
 import {FilesModule} from './files';
 import {HealthModule} from './health';
 import {fixAddProjectFilesOpenAPIDef} from './utils/open-api.utils';
+import {DBMSPluginsModule} from './entities/dbms-plugins';
 
 export interface IWebModuleConfig extends ISystemModuleConfig {
     protocol?: string;
@@ -28,6 +29,7 @@ export interface IWebModuleConfig extends ISystemModuleConfig {
     imports: [
         SystemModule,
         DBMSModule,
+        DBMSPluginsModule,
         DBModule,
         ExtensionModule,
         ProjectModule,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Added resolvers and tests for the following `dbms-plugin` operations:
- `add-sources`
- `list-sources`
- `remove-sources`
- `install`
- `list`
- `uninstall`

### What is the current behavior?
No resolvers or tests for and `dbms-plugins` operations 

### What is the new behavior?
Can now list/add/remove dbms-plugins and sources.


### Does this PR introduce a breaking change?
no


### Other information:
