### PR TITLE
Add autoSchemaFile option to WebModule config

### DIFF
--- a/packages/electron/src/configs/dev.config.ts
+++ b/packages/electron/src/configs/dev.config.ts
@@ -8,4 +8,5 @@ export default (): IElectronModuleConfig => ({
     port: process.env.PORT ? parseInt(process.env.PORT, 10) : DEFAULT_PORT,
     // @todo: https?
     protocol: 'http://',
+    autoSchemaFile: true,
 });

--- a/packages/web/src/configs/dev.config.ts
+++ b/packages/web/src/configs/dev.config.ts
@@ -8,4 +8,5 @@ export default (): IWebModuleConfig => ({
     port: process.env.PORT ? parseInt(process.env.PORT, 10) : DEFAULT_PORT,
     // @todo: https?
     protocol: 'http://',
+    autoSchemaFile: true,
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Add an option in the WebModule config for setting the `autoSchemaFile` value in the GraphQLModule.


### What is the current behavior?
GraphQL schemas are always generated and stored in memory. 


### What is the new behavior?
The WebModule can now be configured to generate the schema locally if needed (eg. for verifying queries with eslint-plugin-graphql).


### Does this PR introduce a breaking change?
No


### Other information:
