### PR TITLE
Install plugins after creating a sample dbms.

### DIFF
--- a/packages/common/src/models/project-install.model.ts
+++ b/packages/common/src/models/project-install.model.ts
@@ -24,6 +24,7 @@ export interface ISampleProjectDbms {
     dumpFile?: string;
     scriptFile?: string;
     targetNeo4jVersion: string;
+    plugins: string[];
 }
 
 export interface ISampleProjectRest {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Checks the `relate.project-install.json` file for `dbms -> plugins[]` which is an array of plugin IDs, if found the plugins are installed after the sample dbms has been created. 


### What is the current behavior?
Plugins are not installed for sample projects.


### What is the new behavior?
Plugins are installed for sample projects.


### Does this PR introduce a breaking change?
No


### Other information:
