### PR TITLE
Improve upgrade error logging

### DIFF
--- a/packages/common/src/utils/dbmss/upgrade-neo4j.ts
+++ b/packages/common/src/utils/dbmss/upgrade-neo4j.ts
@@ -84,6 +84,9 @@ export const upgradeNeo4j = async (
         throw new InvalidArgumentError(`Can only upgrade stopped dbms`, ['Stop dbms']);
     }
 
+    // The upgrade will fail if the DBMS folder is locked by another process, so we check here first
+    // N.B. if the folder gets locked after this check that could still fail the upgrade, but this should catch
+    // most typical cases
     await checkDbmsFolderIsNotLocked(env, dbmsId);
 
     const {entityType, entityId} = await emitHookEvent(HOOK_EVENTS.BACKUP_START, {


### PR DESCRIPTION
### Please check if the PR fulfils these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Feature


### What is the current behaviour?
If a DBMS folder is locked, the DBMS upgrade process fails midway through. An `EBUSY` error is thrown. The catch block tries to clean up but runs into problems:
- uninstalling the DBMS errors, and that error is swallowed
- moving the restored DBMS to the original folder errors `dest already exists` and that error is returned => so the original error is lost

No information on what happened is logged out.


### What is the new behaviour?
- The upgrade process begins by trying to open the DBMS folder. If that isn't possible, the upgrade is aborted and a clear error message is returned, explaining either that the file is locked (if the error is `EBUSY`), or cannot be opened
- The catch/cleanup block emits a DEBUG event so that we never completely lose the error even if the cleanup fails
- The uninstall DBMS lines in the catch/cleanup block which were swallowing errors now emit a DEBUG event
- The restore backup & move backup lines now also emit a DEBUG event: this isn't as important, as the error message is rethrown so the end user will see the error, but I thought it was useful for the logs to show the context


### Does this PR introduce a breaking change?
No


### Other information:
See https://github.com/neo-technology/neo4j-desktop/pull/1078 for matching desktop changes.

Ticket: https://trello.com/c/YvQxYvgU/1585-initiating-upgrade-with-windows-terminal-open-to-database-directory-causes-database-operations-to-fail