### PR TITLE
Modify watchInfoDbmss subscription to account for DBMS install/uninstall

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -143,10 +143,10 @@
         "max-depth": "error",
         "max-len": ["error", {"code": 120, "comments": 120, "ignoreUrls": true}],
         "max-lines": ["warn", 500],
-        "max-lines-per-function": ["warn", 100],
+        "max-lines-per-function": ["off"],
         "max-nested-callbacks": ["error", 5],
         "max-params": ["warn", 4],
-        "max-statements": "warn",
+        "max-statements": ["off"],
         "max-statements-per-line": "error",
         "new-parens": "error",
         // This rule is conflicting with the new behavior from prettier

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
@@ -29,7 +29,6 @@ const TEST_SOURCE_2: IDbmsPluginSource = {
     versionsUrl: 'https://neo4j-contrib.github.io/test-plugin-2/versions.json',
 };
 
-// eslint-disable-next-line max-statements, max-lines-per-function
 describe('LocalDbmsPlugins', () => {
     let app: TestEnvironment;
     let dbms: IDbmsInfo;

--- a/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
+++ b/packages/common/src/entities/dbms-plugins/dbms-plugins.local.test.ts
@@ -29,6 +29,7 @@ const TEST_SOURCE_2: IDbmsPluginSource = {
     versionsUrl: 'https://neo4j-contrib.github.io/test-plugin-2/versions.json',
 };
 
+// eslint-disable-next-line max-statements, max-lines-per-function
 describe('LocalDbmsPlugins', () => {
     let app: TestEnvironment;
     let dbms: IDbmsInfo;

--- a/packages/web/src/entities/dbms/dbms.resolver.ts
+++ b/packages/web/src/entities/dbms/dbms.resolver.ts
@@ -25,7 +25,7 @@ import {EnvironmentGuard} from '../../guards/environment.guard';
 import {EnvironmentInterceptor} from '../../interceptors/environment.interceptor';
 import {EnvironmentArgs, FilterArgs} from '../../global.types';
 import path from 'path';
-import {DBMS_EVENT_TYPE, pubSub, setWatcher} from '../../utils/file-watcher.utils';
+import {DBMS_EVENT_TYPE, pubSub, setDbmsWatcher} from '../../utils/file-watcher.utils';
 import {DBMSS_PID_FILE_GLOB} from '../../constants';
 import {FSWatcher} from 'chokidar';
 
@@ -120,7 +120,7 @@ export class DBMSResolver {
             watchPaths.push(path.join(environment.dirPaths.dbmssData, DBMSS_PID_FILE_GLOB));
             // watch dbmss directory
             watchPaths.push(path.join(environment.dirPaths.dbmssData));
-            const watcher = setWatcher(watchPaths);
+            const watcher = setDbmsWatcher(watchPaths);
 
             // keep a record of environment watcher
             environmentWatchers.set(environment.id, watcher);

--- a/packages/web/src/entities/dbms/dbms.types.ts
+++ b/packages/web/src/entities/dbms/dbms.types.ts
@@ -44,6 +44,21 @@ export class DbmsInfo extends Dbms {
     prerelease?: string;
 }
 
+@ObjectType()
+export class DbmsSubscription {
+    @Field(() => [DbmsInfo], {nullable: true})
+    started?: [DbmsInfo];
+
+    @Field(() => [DbmsInfo], {nullable: true})
+    stopped?: [DbmsInfo];
+
+    @Field(() => [DbmsInfo], {nullable: true})
+    installed?: [DbmsInfo];
+
+    @Field(() => [String], {nullable: true})
+    uninstalled?: [string];
+}
+
 @ArgsType()
 export class DbmsArgs extends EnvironmentArgs {
     @Field(() => String)

--- a/packages/web/src/utils/file-watcher.utils.ts
+++ b/packages/web/src/utils/file-watcher.utils.ts
@@ -1,25 +1,65 @@
 import chokidar, {FSWatcher} from 'chokidar';
 import {PubSub} from 'graphql-subscriptions';
+import {debounce} from 'lodash';
+import path from 'path';
 
 // @todo: should replace this in production: https://docs.nestjs.com/graphql/subscriptions#code-first
 export const pubSub = new PubSub();
 
-export const setWatcher = (watchPath: string): FSWatcher => {
+export enum DBMS_EVENT_TYPE {
+    STARTED = 'started',
+    STOPPED = 'stopped',
+    INSTALLED = 'installed',
+    UNINSTALLED = 'uninstalled',
+}
+
+// @todo: currently geared towards watching DBMS files/folders specifically
+export const setWatcher = (watchPath: string[]): FSWatcher => {
     const watcher = chokidar.watch(watchPath, {
         persistent: true,
         ignoreInitial: true,
     });
 
-    // determine dbmsId from chokidar event
-    const eventHandler = (e: string) => {
-        const dbmsIdCheck = e.match(/dbms-([^/]+)/);
-        const dbmsId = dbmsIdCheck ? dbmsIdCheck[1] : '';
-        pubSub.publish('infoDbmssUpdate', {dbmsId});
-    };
+    const eventHandler = (eventType: DBMS_EVENT_TYPE) =>
+        debounce(
+            // eslint-disable-next-line max-statements
+            (e: string) => {
+                if (eventType === DBMS_EVENT_TYPE.INSTALLED || eventType === DBMS_EVENT_TYPE.UNINSTALLED) {
+                    // determine dbmsId from chokidar event
+                    // only interested in the top level dir
+                    // so ignore any events with a trailing slash
+                    const dbmsDirIdCheck = e.match(/dbms-([\w-]+[^/]$)/);
+                    const dbmsId = dbmsDirIdCheck ? dbmsDirIdCheck[1] : '';
+                    if (dbmsId) {
+                        pubSub.publish('infoDbmssUpdate', {
+                            dbmsId,
+                            eventType,
+                        });
+                    }
+                }
+                if (eventType === DBMS_EVENT_TYPE.STARTED || DBMS_EVENT_TYPE.STOPPED) {
+                    if (path.extname(e) === '.pid') {
+                        // determine dbmsId from chokidar event
+                        const dbmsIdCheck = e.match(/dbms-([^/]+)/);
+                        const dbmsId = dbmsIdCheck ? dbmsIdCheck[1] : '';
+                        if (dbmsId) {
+                            pubSub.publish('infoDbmssUpdate', {
+                                dbmsId,
+                                eventType,
+                            });
+                        }
+                    }
+                }
+            },
+            500,
+        );
 
     // determine dbms start / stop (add / unlink of pid file respectively)
-    watcher.on('add', eventHandler);
-    watcher.on('unlink', eventHandler);
+    watcher.on('add', eventHandler(DBMS_EVENT_TYPE.STARTED));
+    watcher.on('unlink', eventHandler(DBMS_EVENT_TYPE.STOPPED));
+    // determine dbms install / uninstall (addDir / unlinkDir of top level DBMS dir respectively)
+    watcher.on('addDir', eventHandler(DBMS_EVENT_TYPE.INSTALLED));
+    watcher.on('unlinkDir', eventHandler(DBMS_EVENT_TYPE.UNINSTALLED));
 
     return watcher;
 };

--- a/packages/web/src/utils/file-watcher.utils.ts
+++ b/packages/web/src/utils/file-watcher.utils.ts
@@ -1,7 +1,7 @@
 import chokidar, {FSWatcher} from 'chokidar';
 import {PubSub} from 'graphql-subscriptions';
-import {debounce} from 'lodash';
 import path from 'path';
+import {debounce} from 'lodash';
 
 // @todo: should replace this in production: https://docs.nestjs.com/graphql/subscriptions#code-first
 export const pubSub = new PubSub();
@@ -13,53 +13,54 @@ export enum DBMS_EVENT_TYPE {
     UNINSTALLED = 'uninstalled',
 }
 
-// @todo: currently geared towards watching DBMS files/folders specifically
-export const setWatcher = (watchPath: string[]): FSWatcher => {
+export const setDbmsWatcher = (watchPath: string[]): FSWatcher => {
     const watcher = chokidar.watch(watchPath, {
-        persistent: true,
+        followSymlinks: true,
         ignoreInitial: true,
+        persistent: true,
+        awaitWriteFinish: true,
     });
 
-    const eventHandler = (eventType: DBMS_EVENT_TYPE) =>
+    const fileEventHandler = (eventType: DBMS_EVENT_TYPE.STARTED | DBMS_EVENT_TYPE.STOPPED) => (e: string) => {
+        if (path.extname(e) === '.pid') {
+            // determine dbmsId from chokidar event
+            const dbmsIdCheck = e.match(/dbms-([^/]+)/);
+            const dbmsId = dbmsIdCheck ? dbmsIdCheck[1] : '';
+            if (dbmsId) {
+                pubSub.publish('infoDbmssUpdate', {
+                    dbmsId,
+                    eventType,
+                });
+            }
+        }
+    };
+
+    const dirEventHandler = (eventType: DBMS_EVENT_TYPE.INSTALLED | DBMS_EVENT_TYPE.UNINSTALLED) =>
+        // debounce for now as multiple events for addDir (different flags)
         debounce(
-            // eslint-disable-next-line max-statements
             (e: string) => {
-                if (eventType === DBMS_EVENT_TYPE.INSTALLED || eventType === DBMS_EVENT_TYPE.UNINSTALLED) {
-                    // determine dbmsId from chokidar event
-                    // only interested in the top level dir
-                    // so ignore any events with a trailing slash
-                    const dbmsDirIdCheck = e.match(/dbms-([\w-]+[^/]$)/);
-                    const dbmsId = dbmsDirIdCheck ? dbmsDirIdCheck[1] : '';
-                    if (dbmsId) {
-                        pubSub.publish('infoDbmssUpdate', {
-                            dbmsId,
-                            eventType,
-                        });
-                    }
-                }
-                if (eventType === DBMS_EVENT_TYPE.STARTED || DBMS_EVENT_TYPE.STOPPED) {
-                    if (path.extname(e) === '.pid') {
-                        // determine dbmsId from chokidar event
-                        const dbmsIdCheck = e.match(/dbms-([^/]+)/);
-                        const dbmsId = dbmsIdCheck ? dbmsIdCheck[1] : '';
-                        if (dbmsId) {
-                            pubSub.publish('infoDbmssUpdate', {
-                                dbmsId,
-                                eventType,
-                            });
-                        }
-                    }
+                // determine dbmsId from chokidar event
+                // only interested in the top level dir
+                // so ignore any events with a trailing slash
+                const dbmsDirIdCheck = e.match(/dbms-([\w-]+[^/]$)/);
+                const dbmsId = dbmsDirIdCheck ? dbmsDirIdCheck[1] : '';
+                if (dbmsId) {
+                    pubSub.publish('infoDbmssUpdate', {
+                        dbmsId,
+                        eventType,
+                    });
                 }
             },
             500,
+            {trailing: true},
         );
 
     // determine dbms start / stop (add / unlink of pid file respectively)
-    watcher.on('add', eventHandler(DBMS_EVENT_TYPE.STARTED));
-    watcher.on('unlink', eventHandler(DBMS_EVENT_TYPE.STOPPED));
+    watcher.on('add', fileEventHandler(DBMS_EVENT_TYPE.STARTED));
+    watcher.on('unlink', fileEventHandler(DBMS_EVENT_TYPE.STOPPED));
     // determine dbms install / uninstall (addDir / unlinkDir of top level DBMS dir respectively)
-    watcher.on('addDir', eventHandler(DBMS_EVENT_TYPE.INSTALLED));
-    watcher.on('unlinkDir', eventHandler(DBMS_EVENT_TYPE.UNINSTALLED));
+    watcher.on('addDir', dirEventHandler(DBMS_EVENT_TYPE.INSTALLED));
+    watcher.on('unlinkDir', dirEventHandler(DBMS_EVENT_TYPE.UNINSTALLED));
 
     return watcher;
 };


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
- adds debounce to the file event handler
- publish for DBMS install/uninstall events
- return structure is different, with a property for each event type (see screenshots)
- Note - currently can only return the DBMS ID when an uninstall occurs since that is the only info we would have from Chokidar and so cannot use `dbmss.info` after this point with this DBMS ID (since its deleted).

### What is the current behavior?
- DBMS install / uninstall will publish any new events for the subscription resolver

### What is the new behavior?
- New structure with DBMS install / uninstall published 


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
Yes - when introduced we would need to make adjustments wherever the `watchInfoDbmss` subscription has been used -  Desktop 2.0 and the Sample App.

### Other information
![Screenshot 2021-11-12 at 10 37 03](https://user-images.githubusercontent.com/14161129/141461194-a916631e-4c8c-4c5e-95f3-608e4a42f69f.png)
![Screenshot 2021-11-12 at 10 36 51](https://user-images.githubusercontent.com/14161129/141461207-ad3c580b-76d4-40da-886a-d83a2fb83e33.png)
