### PR TITLE
Use NestMiddleware to register token handlers

### DIFF
--- a/packages/web/src/auth/auth.module.ts
+++ b/packages/web/src/auth/auth.module.ts
@@ -1,19 +1,40 @@
 import {HttpAdapterHost} from '@nestjs/core';
-import {Inject, Module, OnModuleInit} from '@nestjs/common';
+import {Inject, MiddlewareConsumer, Module, NestModule, OnModuleInit, RequestMethod} from '@nestjs/common';
 import {SystemModule} from '@relate/common';
 
 import {AuthService} from './services/auth.service';
+import {ApiTokenMiddleware} from './middleware/api-token.middleware';
+import {AuthTokenMiddleware} from './middleware/auth-token.middleware';
+import cookieParser from 'cookie-parser';
 
 @Module({
     exports: [AuthService],
     imports: [SystemModule],
     providers: [AuthService],
 })
-export class AuthModule implements OnModuleInit {
+export class AuthModule implements OnModuleInit, NestModule {
     constructor(
         @Inject(HttpAdapterHost) private readonly httpAdapterHost: HttpAdapterHost,
         @Inject(AuthService) private readonly loader: AuthService,
     ) {}
+
+    configure(consumer: MiddlewareConsumer) {
+        consumer.apply(cookieParser()).forRoutes('*');
+
+        consumer
+            .apply(ApiTokenMiddleware, AuthTokenMiddleware)
+            .exclude(
+                {
+                    path: '/graphql',
+                    method: RequestMethod.GET,
+                },
+                {
+                    path: '/api-docs',
+                    method: RequestMethod.GET,
+                },
+            )
+            .forRoutes('*');
+    }
 
     onModuleInit(): void {
         if (!this.httpAdapterHost) {

--- a/packages/web/src/auth/middleware/api-token.middleware.ts
+++ b/packages/web/src/auth/middleware/api-token.middleware.ts
@@ -1,0 +1,47 @@
+import {Inject, Injectable, NestMiddleware} from '@nestjs/common';
+import {NextFunction, Request, Response} from 'express';
+import _ from 'lodash';
+import {
+    SystemProvider,
+    HEALTH_BASE_ENDPOINT,
+    CLIENT_ID_HEADER,
+    API_TOKEN_HEADER,
+    STATIC_APP_BASE_ENDPOINT,
+} from '@relate/common';
+import {getRequestToken} from '../services/auth.service';
+
+@Injectable()
+export class ApiTokenMiddleware implements NestMiddleware {
+    constructor(@Inject(SystemProvider) private readonly systemProvider: SystemProvider) {}
+
+    async use(req: Request, res: Response, next: NextFunction) {
+        if (_.startsWith(req.path, HEALTH_BASE_ENDPOINT) || _.startsWith(req.path, STATIC_APP_BASE_ENDPOINT)) {
+            next();
+            return;
+        }
+
+        const clientId = getRequestToken(req, CLIENT_ID_HEADER) || '';
+        const apiToken = getRequestToken(req, API_TOKEN_HEADER) || '';
+        const environment = await this.systemProvider.getEnvironment();
+
+        if (!environment.requiresAPIToken) {
+            next();
+            return;
+        }
+
+        const origin = req.get('origin');
+        // Use the client URL otherwise fallback to the Relate server URL.
+        // Requests coming from files might contain either 'null' or 'file://' in the Origin header.
+        const requestUrl = origin && origin !== 'null' && new URL(origin).host ? origin : environment.httpOrigin;
+        const requestHost = new URL(requestUrl).host;
+
+        try {
+            await environment.verifyAPIToken(requestHost, clientId, apiToken);
+            next();
+        } catch (e) {
+            res.clearCookie(CLIENT_ID_HEADER);
+            res.clearCookie(API_TOKEN_HEADER);
+            res.sendStatus(401);
+        }
+    }
+}

--- a/packages/web/src/auth/middleware/auth-token.middleware.ts
+++ b/packages/web/src/auth/middleware/auth-token.middleware.ts
@@ -1,0 +1,36 @@
+import {Inject, Injectable, NestMiddleware} from '@nestjs/common';
+import {NextFunction, Request, Response} from 'express';
+import _ from 'lodash';
+import {AUTH_TOKEN_HEADER, SystemProvider, AUTHENTICATION_BASE_ENDPOINT, HEALTH_BASE_ENDPOINT} from '@relate/common';
+import {getRequestToken} from '../services/auth.service';
+
+@Injectable()
+export class AuthTokenMiddleware implements NestMiddleware {
+    constructor(@Inject(SystemProvider) private readonly systemProvider: SystemProvider) {}
+
+    async use(req: Request, res: Response, next: NextFunction) {
+        if (_.startsWith(req.path, AUTHENTICATION_BASE_ENDPOINT) || _.startsWith(req.path, HEALTH_BASE_ENDPOINT)) {
+            next();
+            return;
+        }
+
+        const authToken = getRequestToken(req, AUTH_TOKEN_HEADER);
+        const environment = await this.systemProvider.getEnvironment();
+
+        try {
+            await environment.verifyAuthToken(authToken);
+            next();
+        } catch (e) {
+            res.clearCookie(AUTH_TOKEN_HEADER);
+
+            if (req.method !== 'GET') {
+                res.sendStatus(401);
+                return;
+            }
+
+            const {authUrl} = await environment.login(req.url);
+
+            res.redirect(authUrl);
+        }
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix


### What is the current behavior?
Token handlers are registered during the application initialization (they are express middleware functions), but there is no guarantee that they are registered before the routes. This can cause the routes that are initialized before the handlers to not require authentication when they should. I haven't noticed this happening when running `@relate/web` on its own, but I noticed it happening in certain cases when extending the WebModule. 


### What is the new behavior?
Token handlers are registered using Nestjs middleware, ensuring that they are always registered before any route.


### Does this PR introduce a breaking change?
No.


### Other information:
Removes auth for the GraphQL Playground and Swagger API docs. Auth is still needed to be able to fetch types for the autocompletion and docs, but at least it's now possible to load the main interface and pass the token and client ID as HTTP headers from the Playground's UI.