### PR TITLE
Allow URLs for Sample Project dumps and scripts

### DIFF
--- a/packages/cli/src/modules/project/install-sample.module.ts
+++ b/packages/cli/src/modules/project/install-sample.module.ts
@@ -70,7 +70,7 @@ export class InstallSampleModule implements OnApplicationBootstrap {
         cli.action.stop(chalk.green('done'));
 
         cli.action.start(`Creating project '${selected}'.`);
-        const manifests = await environment.projects.installSampleProject(downloadPath, {
+        const manifests = await environment.projects.prepareSampleProject(downloadPath, {
             name: selected,
             temp,
         });

--- a/packages/common/src/entities/projects/projects.abstract.ts
+++ b/packages/common/src/entities/projects/projects.abstract.ts
@@ -1,5 +1,4 @@
 import {List} from '@relate/types';
-import {Got} from 'got';
 
 import {EnvironmentAbstract} from '../environments';
 import {ManifestAbstract} from '../manifest';
@@ -130,7 +129,7 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
     /**
      * Lists sample projects from github (https://github.com/neo4j-graph-examples)
      */
-    abstract listSampleProjects(fetch?: () => any | Got): Promise<List<ISampleProjectRest>>;
+    abstract listSampleProjects(): Promise<List<ISampleProjectRest>>;
 
     /**
      * Download sample project from github (https://github.com/neo4j-graph-examples)
@@ -144,7 +143,7 @@ export abstract class ProjectsAbstract<Env extends EnvironmentAbstract> {
     /**
      * Install sample project from file
      */
-    abstract installSampleProject(
+    abstract prepareSampleProject(
         srcPath: string,
         args: {
             name?: string;

--- a/packages/common/src/entities/projects/projects.remote.ts
+++ b/packages/common/src/entities/projects/projects.remote.ts
@@ -89,7 +89,7 @@ export class RemoteProjects extends ProjectsAbstract<RemoteEnvironment> {
         throw new NotSupportedError(`${RemoteProjects.name} does not support downloading sample projects`);
     }
 
-    installSampleProject(
+    prepareSampleProject(
         _srcPath: string,
         _args: {
             name?: string;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Allows for `dumpFile` or a `scriptFile` in the sample project dbms description to point to a URL instead of a local file. The file will be downloaded before it is imported.

Also removes `got` for `listSampleProjects` and uses `requestJson` instead, which should work with the Desktop proxy. 


### What is the current behavior?
Currently only local files can be defined.


### What is the new behavior?
(if this is a feature change)


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)


### Other information:
