### PR TITLE
Fix e2e tests script and Github action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,32 +23,5 @@ jobs:
 
         steps:
             - uses: actions/checkout@v3
-
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: ${{ inputs.NODE_VERSION }}
-
-            - uses: pnpm/action-setup@v2.2.2
-              id: pnpm-install
-              with:
-                  version: ${{ inputs.PNPM_VERSION }}
-                  run_install: false
-
-            - name: Get pnpm store directory
-              shell: bash
-              id: pnpm-cache
-              run: 'echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"'
-
-            - uses: actions/cache@v3
-              name: Setup pnpm cache
-              with:
-                  path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install dependencies
-              shell: bash
-              run: pnpm install --frozen-lockfile --strict-peer-dependencies --aggregate-output
-
+            - uses: ./.github/workflows/setup
             - run: pnpm test

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -9,7 +9,7 @@ inputs:
     PNPM_VERSION:
         description: PNPM version
         required: false
-        default: 6.31.0
+        default: 7.3.0
 
 runs:
     using: composite

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "eslint . --ext .ts --quiet",
         "test:teardown": "node scripts/tests/teardown.js",
         "test:setup": "node scripts/tests/setup.js",
-        "test:e2e": "pnpm --recursive --workspace-concurrency 1 test",
+        "test:e2e": "pnpm --recursive --filter \"@relate/*\" --workspace-concurrency 1 test",
         "test": "run-s --continue-on-error test:setup test:e2e test:teardown",
         "test:pr": "run-s lint test",
         "generate:licenses": "node scripts/licenses/index.js",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Fix the way we run tests.


### What is the current behavior?
The e2e tests are getting stuck in a loop trying to execute the `test` script from the root level of the repo. This issue only shows up in the release pipeline and not in the PR tests, likely because the pnpm versions used in the two actions are different. 


### What is the new behavior?
All actions are using the same version of pnpm and we filter out the root `test` script when calling `pnpm --recursive test` to avoid an infinite loop. 


### Does this PR introduce a breaking change?
No


### Other information:
