### PR TITLE
Allow 5.0.0 drops to be dowloaded

### DIFF
--- a/.changeset/mean-stingrays-do.md
+++ b/.changeset/mean-stingrays-do.md
@@ -1,0 +1,5 @@
+---
+'@relate/common': patch
+---
+
+Use new set-initial-password syntax for 5.0.

--- a/.changeset/odd-pants-develop.md
+++ b/.changeset/odd-pants-develop.md
@@ -1,0 +1,5 @@
+---
+'@relate/common': patch
+---
+
+Allow Neo4j prereleases to be properly installed

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -67,7 +67,7 @@
         "got": "11.8.5",
         "jsonwebtoken": "8.5.1",
         "lodash": "4.17.21",
-        "neo4j-driver-lite": "4.4.6",
+        "neo4j-driver-lite": "5.0.0-alpha01",
         "node-forge": "1.3.1",
         "p-limit": "3.1.0",
         "rxjs": "7.5.6",

--- a/packages/common/src/entities/dbmss/dbmss.abstract.ts
+++ b/packages/common/src/entities/dbmss/dbmss.abstract.ts
@@ -57,6 +57,7 @@ export abstract class DbmssAbstract<Env extends EnvironmentAbstract> {
         overrideCache?: boolean,
         limited?: boolean,
         installPath?: string,
+        prerelease?: string,
     ): Promise<IDbmsInfo>;
 
     abstract upgrade(dbmsId: string, version: string, options?: IDbmsUpgradeOptions): Promise<IDbmsInfo>;

--- a/packages/common/src/utils/dbmss/dbms-versions.test.ts
+++ b/packages/common/src/utils/dbmss/dbms-versions.test.ts
@@ -136,9 +136,9 @@ describe('DBMS versions (local environment)', () => {
         };
         nock(neo4jLimitedVersionsUrl.origin).get(neo4jLimitedVersionsUrl.pathname).reply(200, versionReply);
         const versions = (await fetchNeo4jVersions(true)).toArray();
-        expect(versions.length).toEqual(5);
+        expect(versions.length).toEqual(6);
         versions.forEach((v) => {
-            if (!Object.keys(versionReply.versions).includes(v.version)) {
+            if (!Object.keys(versionReply.versions).includes(v.version) && !v.prerelease) {
                 expect(v.origin).toEqual(NEO4J_ORIGIN.ONLINE);
             } else {
                 expect(v.origin).toEqual(NEO4J_ORIGIN.LIMITED);

--- a/packages/common/src/utils/dbmss/download-neo4j.ts
+++ b/packages/common/src/utils/dbmss/download-neo4j.ts
@@ -1,5 +1,6 @@
 import fse from 'fs-extra';
 import {Str} from '@relate/types';
+import semver from 'semver';
 
 import {NEO4J_EDITION, NEO4J_SHA_ALGORITHM} from '../../entities/environments/environment.constants';
 import {HOOK_EVENTS} from '../../constants';
@@ -24,9 +25,14 @@ export const downloadNeo4j = async (
     edition: NEO4J_EDITION,
     neo4jDistributionPath: string,
     limited?: boolean,
+    prerelease?: string,
 ): Promise<void> => {
     const onlineVersions = await fetchNeo4jVersions(limited);
-    const requestedDistribution = onlineVersions.find((dist) => dist.version === version && dist.edition === edition);
+
+    const requestedDistribution = onlineVersions.find(
+        (dist) =>
+            `${semver.coerce(dist.version)}` === version && dist.edition === edition && prerelease === dist.prerelease,
+    );
     const errorMessage = () => {
         const mappedVersions = onlineVersions
             .mapEach((dist) => `${dist.version}-${dist.edition}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,7 @@ importers:
       jest: 28.1.3
       jsonwebtoken: 8.5.1
       lodash: 4.17.21
-      neo4j-driver-lite: 4.4.6
+      neo4j-driver-lite: 5.0.0-alpha01
       nock: 12.0.3
       node-forge: 1.3.1
       npm-run-all: 4.1.5
@@ -188,7 +188,7 @@ importers:
       got: 11.8.5
       jsonwebtoken: 8.5.1
       lodash: 4.17.21
-      neo4j-driver-lite: 4.4.6
+      neo4j-driver-lite: 5.0.0-alpha01
       node-forge: 1.3.1
       p-limit: 3.1.0
       rxjs: 7.5.6
@@ -219,7 +219,7 @@ importers:
       nock: 12.0.3
       npm-run-all: 4.1.5
       reflect-metadata: 0.1.13
-      ts-jest: 28.0.7_33d3ydo3msfjevmazphp5np3fe
+      ts-jest: 28.0.7_bi2kohzqnxavgozw3csgny5hju
       typedoc: 0.23.10_typescript@4.7.4
       typedoc-plugin-markdown: 3.13.4_typedoc@0.23.10
       typescript: 4.7.4
@@ -1626,7 +1626,7 @@ packages:
       reflect-metadata: ^0.1.13
       rxjs: ^6.0.0 || ^7.2.0
     dependencies:
-      '@nestjs/common': 8.4.7_allg6cauirbqzgqcmexy2wdnoq
+      '@nestjs/common': 8.4.7_c3ywp5uae7mfm5pv3l6tu7kcju
       dotenv: 16.0.1
       dotenv-expand: 8.0.3
       lodash: 4.17.21
@@ -7688,23 +7688,23 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /neo4j-driver-bolt-connection/4.4.6:
-    resolution: {integrity: sha512-ZjYVwHk8oMeRtBf4j/1CmA/7t88OHl7WOiZtFnbdU3LHkfnhtrovLk7sU1zGK60f6AmaQrA9lAh1rpxwDfri5Q==}
+  /neo4j-driver-bolt-connection/5.0.0-alpha01:
+    resolution: {integrity: sha512-EvdJ9AIIqC1gybMLLh7p/UAq9n5T+jSkbUeMALzVUOudQxJUrJL+I/ZDsgBefXlrclWMrjVr5suoWE0/1OqnbA==}
     dependencies:
       buffer: 6.0.3
-      neo4j-driver-core: 4.4.6
+      neo4j-driver-core: 5.0.0-alpha01
       string_decoder: 1.3.0
     dev: false
 
-  /neo4j-driver-core/4.4.6:
-    resolution: {integrity: sha512-8Pc5lLeWwrxjrEGyJm8QASfguKK90i4YxB4Unz1FWV1z3xRq2xFtLhNl6PSa5Kx1VtKS5dhiwHlJArBJJEQjZA==}
+  /neo4j-driver-core/5.0.0-alpha01:
+    resolution: {integrity: sha512-6CLe6ydv0bqlh28IdKlw+8bVCawhmfwE8B3AW/hRuln4ASa/G8q10pzZE1+lZcOaK5GceHftnLsBnwaNy9CyVw==}
     dev: false
 
-  /neo4j-driver-lite/4.4.6:
-    resolution: {integrity: sha512-4HXSYi1JfPVS2nkmt4ekfRzmQzNjmKpENh5GOxm70FXSiKItRUGOTHzsSsiIaZlXcYwT8EFP0RTdW7yxLGvxMg==}
+  /neo4j-driver-lite/5.0.0-alpha01:
+    resolution: {integrity: sha512-I9q4kYKF1PvC/sVcqDutmoGohDhsnFKLL2+BZTVbWvU7fS/cOALkn6LcFjU4E9zMv01UjzKT5pvKc8dagq2kXA==}
     dependencies:
-      neo4j-driver-bolt-connection: 4.4.6
-      neo4j-driver-core: 4.4.6
+      neo4j-driver-bolt-connection: 5.0.0-alpha01
+      neo4j-driver-core: 5.0.0-alpha01
     dev: false
 
   /nice-try/1.0.5:
@@ -9809,6 +9809,39 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.18.5
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 28.1.3_@types+node@16.11.45
+      jest-util: 28.1.1
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.7.4
+      yargs-parser: 21.0.1
+    dev: true
+
+  /ts-jest/28.0.7_bi2kohzqnxavgozw3csgny5hju:
+    resolution: {integrity: sha512-wWXCSmTwBVmdvWrOpYhal79bDpioDy4rTT+0vyUnE3ZzM7LOAAGG9NXwzkEL/a516rQEgnMmS/WKP9jBPCVJyA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^28.0.0
+      babel-jest: ^28.0.0
+      esbuild: '*'
+      jest: ^28.0.0
+      typescript: '>=4.3'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 28.1.3_@types+node@16.11.45


### PR DESCRIPTION
5.0.0-drop0X.0 are causing issues with version checks when downloading, this fixes those issues.

### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
This change version checks to allow `drop0X.0` prereleases to be downloaded. 


### What is the current behavior?
`drop0X.0` version checks fail to download with an error.


### What is the new behavior?
`drop0X.0` versions are downloaded and installed successfully.


### Does this PR introduce a breaking change?



### Other information:
