### PR TITLE
Fix version script on release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
               id: changesets
               uses: changesets/action@v1
               with:
-                  version: pnpm changeset version && pnpm generate:docs
+                  version: pnpm run version
                   publish: pnpm changeset publish
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "test:pr": "run-s lint test",
         "generate:licenses": "node scripts/licenses/index.js",
         "generate:docs": "pnpm --recursive --parallel generate:docs",
-        "watch": "pnpm --recursive --parallel watch"
+        "watch": "pnpm --recursive --parallel watch",
+        "version": "pnpm changeset version && pnpm generate:docs"
     },
     "devDependencies": {
         "@changesets/cli": "2.23.2",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
The changeset action is currently not working because it's running the script in the `version` variable as one command and we need to run two commands, one for bumping the package versions, and one for re-generating the docs.

https://github.com/neo4j-devtools/relate/runs/8017704687?check_suite_focus=true#step:4:26

### Does this PR introduce a breaking change?
No
