### PR TITLE
Allow hyphens in db name when doing a DROP DATABASE

### DIFF
--- a/packages/common/src/entities/dbs/dbs.local.ts
+++ b/packages/common/src/entities/dbs/dbs.local.ts
@@ -42,7 +42,7 @@ export class LocalDbs extends DbsAbstract<LocalEnvironment> {
                 dbmsNameOrId,
                 dbmsUser,
             },
-            `DROP DATABASE ${dbName}`,
+            `DROP DATABASE ${`\`${dbName}\``}`,
         );
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Allow hyphens in db name when doing a DROP DATABASE

### What is the current behavior?
Relate fails to drop a db containing a hyphen


### What is the new behavior?
Relate succeeds when dropping a db containing a hyphen


### Does this PR introduce a breaking change?
--


### Other information:
See issue #397 
