### PR TITLE
Update global .npmrc instead of local one on release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
                   token: ${{ secrets.GH_PAT_PULL_REQUEST }}
             - uses: ./.github/workflows/setup
 
-            - name: Update .npmrc
-              run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
+            - name: Update npm config
+              run: npm config set '//registry.npmjs.org/:_authToken' '${NPM_TOKEN}'
 
             # Create a pull request with all of the package versions and
             # changelogs updated and when there are new changesets on master,

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,3 @@ e2e/relate fixtures/data/
 e2e/relate fixtures/cache/
 e2e/fixtures/data/
 e2e/fixtures/cache/
-
-# Changes to npmrc should be ignored during the release process
-.npmrc
-


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Git can't ignore a tracked file, so the change from #420 is not working. This results in the release pipeline still failing because the working is unclean after we update the .npmrc file. 

This PR reverts ignoring the .npmrc file (which didn't work) and updates the release action to modify the user npm config instead of the local one. 

### Does this PR introduce a breaking change?
No
