### PR TITLE
Adjust dump/load with support for 5.0

### DIFF
--- a/packages/common/src/entities/dbs/dbs.local.ts
+++ b/packages/common/src/entities/dbs/dbs.local.ts
@@ -95,14 +95,20 @@ export class LocalDbs extends DbsAbstract<LocalEnvironment> {
 
     async dump(nameOrId: string, database: string, to: string, javaPath?: string): Promise<string> {
         const dbms = await this.environment.dbmss.get(nameOrId);
-        const params = ['dump', `--database=${database}`, `--to=${to}`];
+        const params =
+            dbms.version && semver.satisfies(dbms.version, NEO4J_VERSION_5X, {includePrerelease: true})
+                ? ['database', 'dump', `--to-path=${to}`, database]
+                : ['dump', `--database=${database}`, `--to=${to}`];
         const result = await neo4jAdminCmd(await this.resolveDbmsRootPath(dbms.id), params, '', javaPath);
         return result;
     }
 
     async load(nameOrId: string, database: string, from: string, force?: boolean, javaPath?: string): Promise<string> {
         const dbms = await this.environment.dbmss.get(nameOrId);
-        const params = ['load', `--database=${database}`, `--from=${from}`, ...(force ? ['--force'] : [])];
+        const params =
+            dbms.version && semver.satisfies(dbms.version, NEO4J_VERSION_5X, {includePrerelease: true})
+                ? ['database', 'load', `--from-path=${from}`, database, ...(force ? ['--overwrite-destination'] : [])]
+                : ['load', `--database=${database}`, `--from=${from}`, ...(force ? ['--force'] : [])];
         const result = await neo4jAdminCmd(await this.resolveDbmsRootPath(dbms.id), params, '', javaPath);
         return result;
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Adjusts the dump and load commands to support 5.x.


### What is the current behavior?
Dumps and loads crashes when using a 5.x dbms.


### What is the new behavior?
New params are used for 5.x dumps and loads.


### Does this PR introduce a breaking change?



### Other information:
