### PR TITLE
Tweak watchDbmss to observe changes in the server status rather then the process status

### DIFF
--- a/.changeset/large-poets-fail.md
+++ b/.changeset/large-poets-fail.md
@@ -1,0 +1,5 @@
+---
+'@relate/web': patch
+---
+
+Tweak watchDbmss subscription to observe server rather than process status. No longer require IDs array on infoDbmss query.

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -13,12 +13,12 @@ jobs:
             github.event.pull_request.user.login != 'team-devtools-bot'
 
         runs-on: ubuntu-latest
-
+        environment: pull-request
         steps:
             - uses: actions/checkout@v3
               with:
                   repository: neo-technology/whitelist-check
-                  token: ${{ secrets.GH_PAT_PULL_REQUEST }}
+                  token: ${{ secrets.GH_PAT_READ_ONLY }}
             - uses: actions/setup-python@v4
               with:
                   python-version: 3
@@ -30,6 +30,6 @@ jobs:
             - run: |
                   owner=$(echo "$GITHUB_REPOSITORY" | cut -d/ -f1)
                   repository=$(echo "$GITHUB_REPOSITORY" | cut -d/ -f2)
-                  ./bin/examine-pull-request "$owner" "$repository" "${{ secrets.GH_PAT_PULL_REQUEST }}" "$PULL_REQUEST_NUMBER" cla-database.csv
+                  ./bin/examine-pull-request "$owner" "$repository" "${{ secrets.GH_PAT_READ_ONLY }}" "$PULL_REQUEST_NUMBER" cla-database.csv
               env:
                   PULL_REQUEST_NUMBER: ${{ github.event.number }}

--- a/packages/web/src/entities/dbms/dbms.resolver.ts
+++ b/packages/web/src/entities/dbms/dbms.resolver.ts
@@ -158,8 +158,11 @@ export class DBMSResolver {
                     dbmsInfo = payload.dbmsId;
                     break;
                 }
-                default:
+                default: {
+                    const dbmssInfo = await dbmss.info([payload.dbmsId], true);
+                    dbmsInfo = dbmssInfo.first.getOrElse(null);
                     break;
+                }
             }
 
             return {[payload.eventType]: dbmsInfo};

--- a/packages/web/src/entities/dbms/dbms.resolver.ts
+++ b/packages/web/src/entities/dbms/dbms.resolver.ts
@@ -1,6 +1,15 @@
 import {Resolver, Args, Mutation, Query, Context, Subscription} from '@nestjs/graphql';
 import {Inject, UseGuards, UseInterceptors} from '@nestjs/common';
-import {Environment, SystemProvider, PUBLIC_GRAPHQL_METHODS, IDbms, IDbmsInfo, IDbmsVersion} from '@relate/common';
+import {
+    Environment,
+    SystemProvider,
+    PUBLIC_GRAPHQL_METHODS,
+    IDbms,
+    IDbmsInfo,
+    IDbmsVersion,
+    waitForDbmsToBeOnline,
+    waitForDbmsToStop,
+} from '@relate/common';
 import {List} from '@relate/types';
 
 import {
@@ -21,6 +30,7 @@ import {
     UpgradeDbmsArgs,
     DbmsEvent,
     StopDbmssArgs,
+    InfoDbmssArgs,
 } from './dbms.types';
 import {EnvironmentGuard} from '../../guards/environment.guard';
 import {EnvironmentInterceptor} from '../../interceptors/environment.interceptor';
@@ -29,6 +39,7 @@ import path from 'path';
 import {DBMS_EVENT_TYPE, pubSub, setDbmsWatcher} from '../../utils/file-watcher.utils';
 import {DBMSS_PID_FILE_GLOB} from '../../constants';
 import {FSWatcher} from 'chokidar';
+import {LocalEnvironment} from '@relate/common/dist/entities/environments';
 
 const environmentWatchers: Map<string, FSWatcher> = new Map();
 
@@ -97,23 +108,65 @@ export class DBMSResolver {
     @Query(() => [DbmsInfo])
     async [PUBLIC_GRAPHQL_METHODS.INFO_DBMSS](
         @Context('environment') environment: Environment,
-        @Args() {dbmsIds, onlineCheck}: DbmssArgs,
+        @Args() {dbmsIds, onlineCheck}: InfoDbmssArgs,
     ): Promise<List<IDbmsInfo>> {
-        return environment.dbmss.info(dbmsIds, onlineCheck);
+        if (dbmsIds && dbmsIds.length > 0) {
+            return environment.dbmss.info(dbmsIds, onlineCheck);
+        }
+
+        const dbmsList = await environment.dbmss.list();
+        const ids = dbmsList.mapEach((dbms) => dbms.id);
+        return environment.dbmss.info(ids, onlineCheck);
     }
 
     @Subscription(() => DbmsEvent, {
-        resolve: async (payload: any, _variables: any, context: any) => {
-            return {
-                [payload.eventType]:
-                    payload.eventType !== DBMS_EVENT_TYPE.UNINSTALLED
-                        ? await context.environment.dbmss.info([payload.dbmsId])
-                        : [payload.dbmsId],
-            };
+        resolve: async (
+            payload: {eventType: DBMS_EVENT_TYPE; dbmsId: string},
+            _variables: any,
+            context: {environment: LocalEnvironment},
+        ) => {
+            const {dbmss} = context.environment;
+
+            let dbmsInfo: IDbmsInfo | string;
+            switch (payload.eventType) {
+                case DBMS_EVENT_TYPE.STARTED: {
+                    const dbms = await dbmss.get(payload.dbmsId);
+                    const config = await dbmss.getDbmsConfig(payload.dbmsId);
+
+                    await waitForDbmsToBeOnline({
+                        ...dbms,
+                        config,
+                    });
+
+                    const dbmssInfo = await dbmss.info([payload.dbmsId], true);
+                    dbmsInfo = dbmssInfo.first.getOrElse(null);
+                    break;
+                }
+                case DBMS_EVENT_TYPE.STOPPED: {
+                    await waitForDbmsToStop(context.environment, payload.dbmsId);
+
+                    const dbmssInfo = await dbmss.info([payload.dbmsId], true);
+                    dbmsInfo = dbmssInfo.first.getOrElse(null);
+                    break;
+                }
+                case DBMS_EVENT_TYPE.INSTALLED: {
+                    const dbmssInfo = await dbmss.info([payload.dbmsId]);
+                    dbmsInfo = dbmssInfo.first.getOrElse(null);
+                    break;
+                }
+                case DBMS_EVENT_TYPE.UNINSTALLED: {
+                    dbmsInfo = payload.dbmsId;
+                    break;
+                }
+                default:
+                    break;
+            }
+
+            return {[payload.eventType]: dbmsInfo};
         },
     })
     async [PUBLIC_GRAPHQL_METHODS.WATCH_DBMSS](
-        @Context('environment') environment: Environment,
+        @Context('environment') environment: LocalEnvironment,
     ): Promise<AsyncIterator<unknown, any, undefined>> {
         if (!environmentWatchers.get(environment.id)) {
             const watchPaths = [];

--- a/packages/web/src/entities/dbms/dbms.types.ts
+++ b/packages/web/src/entities/dbms/dbms.types.ts
@@ -49,17 +49,17 @@ export class DbmsInfo extends Dbms {
 
 @ObjectType()
 export class DbmsEvent {
-    @Field(() => [DbmsInfo], {nullable: true})
-    started?: [DbmsInfo];
+    @Field(() => DbmsInfo, {nullable: true})
+    started?: DbmsInfo;
 
-    @Field(() => [DbmsInfo], {nullable: true})
-    stopped?: [DbmsInfo];
+    @Field(() => DbmsInfo, {nullable: true})
+    stopped?: DbmsInfo;
 
-    @Field(() => [DbmsInfo], {nullable: true})
-    installed?: [DbmsInfo];
+    @Field(() => DbmsInfo, {nullable: true})
+    installed?: DbmsInfo;
 
-    @Field(() => [String], {nullable: true})
-    uninstalled?: [string];
+    @Field(() => String, {nullable: true})
+    uninstalled?: string;
 }
 
 @ArgsType()
@@ -72,6 +72,12 @@ export class DbmsArgs extends EnvironmentArgs {
 export class DbmssArgs extends EnvironmentArgs {
     @Field(() => [String])
     dbmsIds: string[];
+}
+
+@ArgsType()
+export class InfoDbmssArgs extends EnvironmentArgs {
+    @Field(() => [String], {nullable: true})
+    dbmsIds?: string[];
 
     @Field(() => Boolean, {nullable: true})
     onlineCheck?: boolean;


### PR DESCRIPTION


### Please check if the PR fulfills these requirements
- [ ] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?

- `infoDbmss` no longer requires an array of IDs, and when no ID is provided we return the entire list of DBMSs and their status. This is to avoid having to send two separate requests for getting the status of all DBMSs.

- `watchDbmss` now sends events for STARTED and STOPPED **after** we confirmed that the Neo4j server status is online or offline. The previous behavior would react to the change in the file system and send whatever status we had at the time the change happened. That could result for example in a STARTED event being created after the DBMS process started (the PID file was created) but before the server was online.

### Does this PR introduce a breaking change?
No


### Other information:
