### PR TITLE
fix(relate): allow apple silicon dists to be downloaded

### DIFF
--- a/.changeset/loud-beans-burn.md
+++ b/.changeset/loud-beans-burn.md
@@ -1,0 +1,5 @@
+---
+'@relate/common': major
+---
+
+Allow Apple Silicon Java dists to be downloaded

--- a/packages/common/src/utils/dbmss/resolve-java.ts
+++ b/packages/common/src/utils/dbmss/resolve-java.ts
@@ -18,25 +18,29 @@ interface IJavaName {
 }
 
 export const resolveJavaName = (dbmsVersion: string): IJavaName => {
-    if (process.arch !== 'x64') {
+    if (!['x64', 'arm64'].includes(process.arch)) {
         throw new NotSupportedError('Unsupported architecture, install Java manually');
     }
 
     let platform: string;
     let ext: string;
+    let arch: string;
 
     switch (process.platform) {
         case 'darwin':
             platform = 'macosx';
             ext = 'tar.gz';
+            arch = process.arch === 'arm64' ? 'aarch64' : 'x64';
             break;
         case 'win32':
             platform = 'win';
             ext = 'zip';
+            arch = 'x64';
             break;
         default:
             platform = 'linux';
             ext = 'tar.gz';
+            arch = 'x64';
     }
 
     const majorVersion = semver.major(dbmsVersion);
@@ -47,7 +51,7 @@ export const resolveJavaName = (dbmsVersion: string): IJavaName => {
     };
     const javaVersion = neo4jJavaVersionMapping[majorVersion] || ZULU_JAVA_VERSION.JAVA_17;
 
-    const dirname = `zulu${javaVersion}-${platform}_${process.arch}`;
+    const dirname = `zulu${javaVersion}-${platform}_${arch}`;
 
     return {
         archive: `${dirname}.${ext}`,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/neo4j-devtools/relate/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Allow `arm64` java dists for Apple Silicon to be downloaded.


### What is the current behavior?
`arm64` dists are blocked from being downloaded.


### What is the new behavior?


### Does this PR introduce a breaking change?


### Other information:
